### PR TITLE
v1.2.0 — within-stage crash-resume + graceful budget halt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,47 @@ All notable changes to **designdoc** are documented here. Format follows
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-04-21
+
+Within-stage crash-resume. A pipeline killed mid-Stage-N no longer loses
+that stage's partial progress — the rerun skips any artifact whose
+input hash still matches the checkpoint. Budget-cap halts are now
+graceful exits with a resume-message format.
+
+### Added
+
+- **Within-stage checkpointing.** Stages 2 (file summaries), 3 (class
+  docs), 4 (package rollups), 5 (mermaid), and 6 (tech-debt topics) now
+  write to `state.artifact_index` after every completed artifact, under
+  an `asyncio.Lock`. Mid-stage crash + rerun never re-calls the LLM for
+  already-produced artifacts.
+- **Atomic artifact writes.** New `designdoc.io_utils.atomic_write(path,
+  content)` writes to a sibling `.tmp` then `os.replace()` (POSIX-atomic).
+  Every artifact and the `.designdoc-state.json` file itself use it.
+- **Graceful budget halt.** `BudgetExceededError` mid-stage now sets
+  `state.halted_on_budget=True`, marks the stage FAILED, saves state, and
+  the CLI prints `budget exhausted at $X / cap $Y. Run` `designdoc resume
+  --budget <new-cap>` `to continue` with exit 0.
+- **Observability.** Orchestrator stage-start log lines include the
+  count of already-checkpointed artifacts (e.g., `[3/9] stage class_docs:
+  40 artifacts checkpointed`).
+
+### Changed
+
+- `PipelineState.artifact_index` is now `dict[str, dict[str, str]]`
+  (was `dict[str, str]`) carrying `{"path": ..., "input_hash": ...}`
+  per artifact. Old-shape state files are migrated in-memory on load
+  with empty `input_hash` — safe fallback that forces reprocessing.
+- `Orchestrator.run()` no longer re-raises `BudgetExceededError`. The
+  CLI reads `state.halted_on_budget` after the run and formats the
+  resume message itself. Exit code 0 (resumable), not 4 (crash).
+
+### Fixed
+
+- Concurrent `state.save()` under `asyncio.gather` is now serialized by
+  a module-level `asyncio.Lock`, preventing lost writes when
+  `parallelism > 1`.
+
 ## [1.1.0] - 2026-04-17
 
 Incremental regeneration, parallel execution, and UX polish. Measured on
@@ -116,5 +157,6 @@ documentation pipeline described in `plans/2026_04_16_designdoc_gen_v1.md`.
 - `mmdc` preflight probe at orchestrator start; pipeline halts with a clear
   error if the Mermaid CLI is absent.
 
+[1.2.0]: https://github.com/SpillwaveSolutions/docgen/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/SpillwaveSolutions/docgen/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/SpillwaveSolutions/docgen/releases/tag/v1.0.0

--- a/plugins/designdoc/plugin.json
+++ b/plugins/designdoc/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "designdoc",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Generate validated design documentation for any codebase",
   "author": "Rick Hightower (Spillwave)",
   "license": "MIT",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "designdoc"
-version = "1.1.0"
+version = "1.2.0"
 description = "Harness-engineered codebase documentation pipeline"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/designdoc/__init__.py
+++ b/src/designdoc/__init__.py
@@ -1,3 +1,3 @@
 """designdoc — harness-engineered codebase documentation pipeline."""
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"

--- a/src/designdoc/cli.py
+++ b/src/designdoc/cli.py
@@ -9,6 +9,7 @@ Four subcommands:
 
 from __future__ import annotations
 
+import json
 import logging
 from pathlib import Path
 from typing import Annotated
@@ -16,7 +17,7 @@ from typing import Annotated
 import anyio
 import typer
 
-from designdoc.budget import BUDGET_FILENAME, BudgetExceededError, CostAccumulator
+from designdoc.budget import BUDGET_FILENAME, CostAccumulator
 from designdoc.config import load_config
 from designdoc.mermaid.mmdc import MmdcNotAvailableError
 from designdoc.orchestrator import Orchestrator
@@ -96,6 +97,11 @@ async def _run_orchestrator(
     # Precedence: explicit --budget wins; otherwise config value wins.
     cap_usd = budget_usd if budget_usd is not None else config.max_budget_usd
     state = PipelineState.load_or_new(output_dir=output, target_repo=repo)
+    # Budget overrides reset the halt flag so a successful rerun clears it.
+    # Without this, a previously-halted run would keep reporting halt even
+    # after the user raised the cap and completed the pipeline.
+    if budget_usd is not None:
+        state.halted_on_budget = False
     budget = CostAccumulator.load_or_new(cap_usd=cap_usd, path=output / BUDGET_FILENAME)
     runner = ClaudeSDKRunner(budget=budget)
     orchestrator = Orchestrator(
@@ -152,10 +158,24 @@ def generate(
         typer.echo(f"mmdc preflight failed: {e}", err=True)
         typer.echo("Use --skip mermaid to proceed without mermaid diagrams.", err=True)
         raise typer.Exit(code=3) from e
-    except BudgetExceededError as e:
-        typer.echo(f"budget exceeded: {e}", err=True)
-        typer.echo("Run `designdoc status` to see the last completed stage.", err=True)
-        raise typer.Exit(code=4) from e
+
+    # Graceful budget halt: orchestrator returned cleanly, state carries the
+    # halt flag. Reload state from disk (fresh process semantics) so the
+    # check works identically on a resume invocation.
+    config_obj = load_config(config) if config else load_config(None)
+    output_dir = _resolve_output(repo_p, output, config_obj.output_dir)
+    state = PipelineState.load_or_new(output_dir=output_dir, target_repo=repo_p)
+    if state.halted_on_budget:
+        budget_path = output_dir / BUDGET_FILENAME
+        spent = "$0.00"
+        cap = "$?.??"
+        if budget_path.exists():
+            data = json.loads(budget_path.read_text())
+            spent = f"${data['total_cost_usd']:.2f}"
+            cap = f"${data['cap_usd']:.2f}"
+        typer.echo(f"budget exhausted at {spent} / cap {cap}.", err=True)
+        typer.echo("Run `designdoc resume --budget <new-cap>` to continue.", err=True)
+        raise typer.Exit(code=0)
 
 
 @app.command()
@@ -207,8 +227,6 @@ def status(
 
     budget_path = out / BUDGET_FILENAME
     if budget_path.exists():
-        import json
-
         data = json.loads(budget_path.read_text())
         typer.echo(
             f"cost: ${data['total_cost_usd']:.4f} / cap ${data['cap_usd']:.2f} "

--- a/src/designdoc/io_utils.py
+++ b/src/designdoc/io_utils.py
@@ -1,0 +1,17 @@
+"""Filesystem helpers with crash-safe semantics.
+
+atomic_write writes to a sibling .tmp file then os.replace(): on POSIX this
+is atomic. A SIGKILL between the two steps leaves either a partial .tmp
+(ignored on next run) or a complete target — never a truncated target.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def atomic_write(path: Path, content: str) -> None:
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(content)
+    os.replace(tmp, path)

--- a/src/designdoc/orchestrator.py
+++ b/src/designdoc/orchestrator.py
@@ -107,7 +107,19 @@ class Orchestrator:
             if self.state.stages.get(entry.name) == StageStatus.DONE:
                 log.info("[%d/%d] stage %s already done, skipping", idx, total, entry.name)
                 continue
-            log.info("[%d/%d] stage %s starting", idx, total, entry.name)
+            prior_count = sum(
+                1 for id_ in self.state.artifact_index if self._id_belongs_to_stage(id_, entry.name)
+            )
+            if prior_count > 0:
+                log.info(
+                    "[%d/%d] stage %s: %d artifacts checkpointed",
+                    idx,
+                    total,
+                    entry.name,
+                    prior_count,
+                )
+            else:
+                log.info("[%d/%d] stage %s starting", idx, total, entry.name)
             start = time.monotonic()
             try:
                 kwargs: dict[str, Any] = {"state": self.state}
@@ -137,6 +149,26 @@ class Orchestrator:
                 entry.name,
                 time.monotonic() - start,
             )
+
+    # Prefix table: maps stage name -> predicate on artifact_id.
+    # Stages 2,4,5,6 use a fixed prefix; Stage 3's class_docs ids are
+    # "<path>::<ClassName>" with no prefix so we detect them by "::"
+    # plus exclusion of other known prefixes.
+    _OTHER_PREFIXES = ("file:", "package:", "mermaid:", "dep:")
+
+    @classmethod
+    def _id_belongs_to_stage(cls, artifact_id: str, stage_name: str) -> bool:
+        if stage_name == "file_analysis":
+            return artifact_id.startswith("file:")
+        if stage_name == "package_rollups":
+            return artifact_id.startswith("package:")
+        if stage_name == "mermaid":
+            return artifact_id.startswith("mermaid:")
+        if stage_name == "tech_debt":
+            return artifact_id.startswith("dep:")
+        if stage_name == "class_docs":
+            return "::" in artifact_id and not artifact_id.startswith(cls._OTHER_PREFIXES)
+        return False
 
     def _stage_kwargs(self, stage_name: str) -> dict[str, Any]:
         """Per-stage kwargs derived from config. Only pass keys the stage accepts.

--- a/src/designdoc/orchestrator.py
+++ b/src/designdoc/orchestrator.py
@@ -2,8 +2,10 @@
 
 Rules:
 - Stages marked DONE are skipped (resume).
-- BudgetExceededError exits cleanly — state is saved with the current stage
-  marked FAILED so subsequent `designdoc status` shows where we halted.
+- BudgetExceededError is caught and turned into state: stage is marked FAILED,
+  state.halted_on_budget is set, state+budget are persisted, and run() returns
+  cleanly (does NOT re-raise). The CLI reads the flag to print a resume hint
+  and exits 0 (the pipeline is resumable; it's not a crash).
 - Stage 5 preflight runs mmdc before the pipeline starts; if mmdc is missing
   and Stage 5 is not skipped, halt with a clear error.
 """
@@ -116,16 +118,18 @@ class Orchestrator:
                 self.budget.save()
             except BudgetExceededError:
                 self.state.stages[entry.name] = StageStatus.FAILED
+                self.state.halted_on_budget = True
                 self.state.save()
                 self.budget.save()
                 log.info(
-                    "[%d/%d] stage %s FAILED after %.1fs (budget exceeded)",
+                    "[%d/%d] stage %s halted after %.1fs (budget exceeded) — "
+                    "run `designdoc resume --budget <new-cap>` to continue",
                     idx,
                     total,
                     entry.name,
                     time.monotonic() - start,
                 )
-                raise
+                return
             log.info(
                 "[%d/%d] stage %s done in %.1fs",
                 idx,

--- a/src/designdoc/stages/s2_file_analysis.py
+++ b/src/designdoc/stages/s2_file_analysis.py
@@ -3,13 +3,10 @@
 For each file in Stage 1's signature list, run the doer/schema loop to produce
 a validated FileSummary. Results persist to stage2_summaries.json.
 
-The "checker" here is NOT an LLM — it's pydantic schema validation. Gen 3
-principle: when a deterministic check suffices, use it; don't burn a second
-API call on a regex-shaped problem.
-
-v1.1 incremental behavior: when state.prev_hashes seeds a current hash map
-and a previous stage2_summaries.json exists, files whose SHA1 is unchanged
-since the last successful run reuse their existing summary — zero LLM calls.
+v1.2 within-stage resume: each completed file updates state.artifact_index
+under state_lock and rewrites stage2_summaries.json atomically. A crash
+mid-stage leaves a partial JSON + partial artifact_index; the rerun skips
+any file whose input hash still matches.
 """
 
 from __future__ import annotations
@@ -18,10 +15,11 @@ import asyncio
 import json
 
 from designdoc.agents.file_analyzer import FileSummary, build_prompt, make_file_analyzer
+from designdoc.io_utils import atomic_write
 from designdoc.loop import doer_schema_loop
 from designdoc.stages.s0_discover import OUTPUT_FILENAME as STAGE0_FILENAME
 from designdoc.stages.s1_index import OUTPUT_FILENAME as STAGE1_FILENAME
-from designdoc.state import PipelineState, StageStatus
+from designdoc.state import PipelineState, StageStatus, state_lock
 
 STAGE_NAME = "file_analysis"
 OUTPUT_FILENAME = "stage2_summaries.json"
@@ -34,40 +32,57 @@ async def run(
     doer_model: str = "claude-sonnet-4-6",
     parallelism: int = 1,
 ) -> dict[str, dict]:
-    """Execute Stage 2. Returns {relative_path: summary_dict}.
-
-    `parallelism` caps concurrent doer invocations via asyncio.Semaphore.
-    Default 1 preserves serial behavior.
-    """
+    """Execute Stage 2. Returns {relative_path: summary_dict}."""
     stage1_path = state.output_dir / STAGE1_FILENAME
     if not stage1_path.exists():
         raise FileNotFoundError(f"stage 1 output missing ({stage1_path}); run stage 1 first")
 
     state.stages[STAGE_NAME] = StageStatus.RUNNING
-    state.save()
+    async with state_lock:
+        state.save()
 
     signatures = json.loads(stage1_path.read_text())
     doer = make_file_analyzer(model=doer_model)
 
-    reusable = _load_reusable_summaries(state)
+    current_hashes = _current_source_hashes(state)
+    reusable = _load_reusable_summaries(state, current_hashes)
 
+    # Load any partial summaries from a prior (possibly crashed) run, then
+    # drop entries for files that no longer exist in the current signatures —
+    # deleted sources must not linger in summaries.
+    existing_path = state.output_dir / OUTPUT_FILENAME
     results: dict[str, dict] = {}
+    if existing_path.exists():
+        try:
+            results = json.loads(existing_path.read_text())
+        except (json.JSONDecodeError, OSError):
+            results = {}
+    current_paths = {s["path"] for s in signatures}
+    results = {p: v for p, v in results.items() if p in current_paths}
+
     to_process: list[dict] = []
     for sig in signatures:
         path = sig["path"]
-        # Skip files that failed to parse in Stage 1 — nothing to summarize.
         if sig.get("parse_error"):
             continue
         if path in reusable:
-            # Unchanged file + previous summary exists — no LLM call needed.
+            # v1.1 cross-run skip: source unchanged since last SUCCESSFUL run.
             results[path] = reusable[path]
+            continue
+        current_hash = current_hashes.get(path, "")
+        artifact_id = f"file:{path}"
+        prior = state.artifact_index.get(artifact_id, {})
+        if prior.get("input_hash") == current_hash and current_hash != "" and path in results:
+            # v1.2 within-stage skip: this file was checkpointed in a prior
+            # (possibly crashed) run of THIS invocation. Nothing to do.
             continue
         to_process.append(sig)
 
     sem = asyncio.Semaphore(max(1, parallelism))
 
-    async def _one(sig: dict) -> tuple[str, dict]:
+    async def _one(sig: dict) -> None:
         path = sig["path"]
+        current_hash = current_hashes.get(path, "")
         async with sem:
             prompt = build_prompt(path, json.dumps(sig, indent=2))
             result = await doer_schema_loop(
@@ -79,48 +94,64 @@ async def run(
                 hil_sink=state.hil_issues,
                 stage_name=STAGE_NAME,
             )
-            return path, _parse_or_placeholder(result.text, path)
+            summary = _parse_or_placeholder(result.text, path)
 
-    for path, summary in await asyncio.gather(*[_one(s) for s in to_process]):
-        results[path] = summary
+        async with state_lock:
+            results[path] = summary
+            atomic_write(
+                state.output_dir / OUTPUT_FILENAME,
+                json.dumps(results, indent=2),
+            )
+            state.artifact_index[f"file:{path}"] = {
+                "path": OUTPUT_FILENAME,
+                "input_hash": current_hash,
+            }
+            state.save()
 
-    (state.output_dir / OUTPUT_FILENAME).write_text(json.dumps(results, indent=2))
-    state.stages[STAGE_NAME] = StageStatus.DONE
-    state.current_stage = max(state.current_stage, 3)
-    state.save()
+    await asyncio.gather(*[_one(s) for s in to_process])
+
+    # Persist the pruned + updated summaries even when no LLM calls fired
+    # (e.g. everything was reusable from prev_hashes and a file was deleted:
+    # the on-disk JSON must drop the stale entry).
+    async with state_lock:
+        atomic_write(
+            state.output_dir / OUTPUT_FILENAME,
+            json.dumps(results, indent=2),
+        )
+        state.stages[STAGE_NAME] = StageStatus.DONE
+        state.current_stage = max(state.current_stage, 3)
+        state.save()
     return results
 
 
-def _load_reusable_summaries(state: PipelineState) -> dict[str, dict]:
-    """Return {path: summary_dict} for files whose previous summary can be
-    reused on this run.
-
-    Eligible when all three hold:
-      1. state.prev_hashes has the path (seen on a prior run).
-      2. Current Stage 0 discovery hashes that path the same.
-      3. The previous stage2_summaries.json still has the entry.
-
-    Any failure to load the upstream JSON -> empty dict (safe default: regenerate).
-    """
+def _current_source_hashes(state: PipelineState) -> dict[str, str]:
+    """Load {path: sha} from stage0_discovery.json; empty dict on any failure."""
     stage0_path = state.output_dir / STAGE0_FILENAME
-    summaries_path = state.output_dir / OUTPUT_FILENAME
-    if not stage0_path.exists() or not summaries_path.exists():
+    if not stage0_path.exists():
         return {}
-    if not state.prev_hashes:
-        return {}
-
     try:
-        current_hashes = json.loads(stage0_path.read_text()).get("hashes") or {}
-        prev_summaries = json.loads(summaries_path.read_text()) or {}
+        return json.loads(stage0_path.read_text()).get("hashes") or {}
     except (json.JSONDecodeError, OSError):
         return {}
 
+
+def _load_reusable_summaries(
+    state: PipelineState, current_hashes: dict[str, str]
+) -> dict[str, dict]:
+    """Cross-run incremental: files whose hash matches prev_hashes AND whose
+    prior summary survives in stage2_summaries.json."""
+    summaries_path = state.output_dir / OUTPUT_FILENAME
+    if not summaries_path.exists() or not state.prev_hashes:
+        return {}
+    try:
+        prev_summaries = json.loads(summaries_path.read_text()) or {}
+    except (json.JSONDecodeError, OSError):
+        return {}
     unchanged = state.unchanged_paths(current_hashes)
     return {path: prev_summaries[path] for path in unchanged if path in prev_summaries}
 
 
 def _parse_or_placeholder(text: str, path: str) -> dict:
-    """Try to parse as FileSummary; fall back to a placeholder that marks HIL."""
     try:
         return FileSummary.model_validate_json(text).model_dump()
     except Exception:

--- a/src/designdoc/stages/s3_class_docs.py
+++ b/src/designdoc/stages/s3_class_docs.py
@@ -14,6 +14,7 @@ doer/checker loop is skipped for every class in that file.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 from pathlib import Path
 
@@ -30,10 +31,11 @@ from designdoc.agents.doc_quality_checker import (
     make_doc_quality_checker,
 )
 from designdoc.hil import inline_comment
+from designdoc.io_utils import atomic_write
 from designdoc.loop import doer_checker_loop
 from designdoc.stages.s0_discover import OUTPUT_FILENAME as STAGE0_FILENAME
 from designdoc.stages.s1_index import OUTPUT_FILENAME as STAGE1_FILENAME
-from designdoc.state import PipelineState, StageStatus
+from designdoc.state import PipelineState, StageStatus, state_lock
 
 STAGE_NAME = "class_docs"
 OUTPUT_SUBDIR = "packages"
@@ -61,32 +63,34 @@ async def run(
     doer = make_class_documenter(model=doer_model)
     checker = make_doc_quality_checker(model=checker_model)
 
-    unchanged_sources = _unchanged_source_paths(state)
+    current_source_hashes = _current_source_hashes(state)
 
-    written: dict[str, str] = {}
     to_process: list[tuple[dict, dict]] = []
     for sig in signatures:
         if sig.get("parse_error") or not sig.get("classes"):
             continue
-        source_unchanged = sig["path"] in unchanged_sources
         for cls in sig["classes"]:
-            class_id = f"{sig['path']}::{cls['name']}"
-            out_path = _class_doc_path(state.output_dir, sig["path"], cls["name"])
-
-            if source_unchanged and out_path.exists():
-                # Source hasn't changed since last successful run and the doc
-                # is already on disk — no LLM call needed.
-                rel = str(out_path.relative_to(state.output_dir))
-                written[class_id] = rel
-                state.artifact_index[class_id] = rel
-                continue
             to_process.append((sig, cls))
 
     sem = asyncio.Semaphore(max(1, parallelism))
 
-    async def _one(sig: dict, cls: dict) -> tuple[str, str]:
+    async def _one(sig: dict, cls: dict) -> None:
         class_id = f"{sig['path']}::{cls['name']}"
         out_path = _class_doc_path(state.output_dir, sig["path"], cls["name"])
+        current_input_hash = _class_input_hash(
+            source_sha=current_source_hashes.get(sig["path"], ""),
+            class_signature=cls,
+        )
+
+        # v1.2 within-stage skip: if we already produced this class with
+        # the same inputs AND the doc exists on disk, no LLM call.
+        prior = state.artifact_index.get(class_id, {})
+        if (
+            prior.get("input_hash") == current_input_hash
+            and current_input_hash != ""
+            and out_path.exists()
+        ):
+            return
 
         async with sem:
             doer_prompt = build_class_prompt(
@@ -112,38 +116,61 @@ async def run(
                 hil_sink=state.hil_issues,
                 stage_name=STAGE_NAME,
             )
-            out_path.parent.mkdir(parents=True, exist_ok=True)
             content = result.text
             if result.status == "shipped_with_hil":
                 hil_id = state.hil_issues[-1]["id"]
                 content = (
                     f"{inline_comment(hil_id, 'doc-quality checker disputed claims')}\n\n" + content
                 )
-            out_path.write_text(content)
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            atomic_write(out_path, content)
             rel = str(out_path.relative_to(state.output_dir))
-            return class_id, rel
 
-    for class_id, rel in await asyncio.gather(*[_one(s, c) for s, c in to_process]):
-        written[class_id] = rel
-        state.artifact_index[class_id] = rel
+        async with state_lock:
+            state.artifact_index[class_id] = {
+                "path": rel,
+                "input_hash": current_input_hash,
+            }
+            state.save()
+
+    await asyncio.gather(*[_one(s, c) for s, c in to_process])
 
     state.stages[STAGE_NAME] = StageStatus.DONE
     state.current_stage = max(state.current_stage, 4)
-    state.save()
+    async with state_lock:
+        state.save()
+
+    # Return the {class_id: path} mapping that downstream stages expect,
+    # sourced from artifact_index so skipped-and-processed classes are
+    # both represented.
+    written: dict[str, str] = {}
+    for sig in signatures:
+        for cls in sig.get("classes", []):
+            class_id = f"{sig['path']}::{cls['name']}"
+            entry = state.artifact_index.get(class_id)
+            if entry:
+                written[class_id] = entry["path"]
     return written
 
 
-def _unchanged_source_paths(state: PipelineState) -> set[str]:
-    """Source paths whose SHA1 matches prev_hashes. Empty if Stage 0 output
-    is missing or unreadable — falls back to full regeneration."""
+def _current_source_hashes(state: PipelineState) -> dict[str, str]:
     stage0_path = state.output_dir / STAGE0_FILENAME
-    if not stage0_path.exists() or not state.prev_hashes:
-        return set()
+    if not stage0_path.exists():
+        return {}
     try:
-        current = json.loads(stage0_path.read_text()).get("hashes") or {}
+        return json.loads(stage0_path.read_text()).get("hashes") or {}
     except (json.JSONDecodeError, OSError):
-        return set()
-    return state.unchanged_paths(current)
+        return {}
+
+
+def _class_input_hash(source_sha: str, class_signature: dict) -> str:
+    """Per-class input hash: source SHA + canonical JSON of the signature."""
+    if not source_sha:
+        return ""
+    h = hashlib.sha1()
+    h.update(source_sha.encode())
+    h.update(json.dumps(class_signature, sort_keys=True).encode())
+    return h.hexdigest()
 
 
 def _class_doc_path(output_dir: Path, source_path: str, class_name: str) -> Path:

--- a/src/designdoc/stages/s4_package_rollups.py
+++ b/src/designdoc/stages/s4_package_rollups.py
@@ -23,8 +23,9 @@ from designdoc.agents.package_documenter import (
     make_package_documenter,
 )
 from designdoc.hil import inline_comment
+from designdoc.io_utils import atomic_write
 from designdoc.loop import doer_checker_loop
-from designdoc.state import PipelineState, StageStatus
+from designdoc.state import PipelineState, StageStatus, state_lock
 
 STAGE_NAME = "package_rollups"
 
@@ -67,6 +68,15 @@ async def run(
     sem = asyncio.Semaphore(max(1, parallelism))
 
     async def _one(pkg_name, class_docs, input_hash, readme_path):
+        rollup_key = f"package:{pkg_name}"
+
+        # v1.2 within-stage skip: if artifact_index already records this
+        # package with the same input_hash and the README exists, skip.
+        prior = state.artifact_index.get(rollup_key, {})
+        if prior.get("input_hash") == input_hash and input_hash != "" and readme_path.exists():
+            rel = str(readme_path.relative_to(state.output_dir))
+            return pkg_name, rel, input_hash
+
         async with sem:
             doer_prompt = build_doer_prompt(pkg_name, class_docs)
 
@@ -74,7 +84,7 @@ async def run(
                 return build_checker_prompt(_pkg, _docs, readme)
 
             result = await doer_checker_loop(
-                artifact_id=f"package:{pkg_name}",
+                artifact_id=rollup_key,
                 doer=doer,
                 checker=checker,
                 doer_prompt=doer_prompt,
@@ -87,14 +97,25 @@ async def run(
             if result.status == "shipped_with_hil":
                 hil_id = state.hil_issues[-1]["id"]
                 content = f"{inline_comment(hil_id, 'package rollup disputed')}\n\n" + content
-            readme_path.write_text(content)
-            return pkg_name, str(readme_path.relative_to(state.output_dir)), input_hash
+            readme_path.parent.mkdir(parents=True, exist_ok=True)
+            atomic_write(readme_path, content)
+            rel = str(readme_path.relative_to(state.output_dir))
 
-    for pkg_name, rel_path, input_hash in await asyncio.gather(
+        async with state_lock:
+            state.artifact_index[rollup_key] = {
+                "path": rel,
+                "input_hash": input_hash,
+            }
+            # v1.1 cross-run skip coexists with v1.2 within-stage skip
+            state.rollup_hashes[rollup_key] = input_hash
+            state.save()
+
+        return pkg_name, rel, input_hash
+
+    for pkg_name, rel_path, _input_hash in await asyncio.gather(
         *[_one(*args) for args in to_process]
     ):
         written[pkg_name] = rel_path
-        state.rollup_hashes[f"package:{pkg_name}"] = input_hash
 
     state.stages[STAGE_NAME] = StageStatus.DONE
     state.current_stage = max(state.current_stage, 5)

--- a/src/designdoc/stages/s5_mermaid.py
+++ b/src/designdoc/stages/s5_mermaid.py
@@ -9,6 +9,11 @@ section. On match with state.rollup_hashes["mermaid:<rel-path>"], skip
 regeneration entirely — the doc is left untouched. This also fixes a
 pre-existing bug where re-running Stage 5 on the same doc would append a
 second Diagram section.
+
+v1.2 within-stage checkpoint: after each diagram is written, persist an
+artifact_index["mermaid:<rel-path>"] entry with the input_hash. On rerun,
+if the entry matches and the class doc still has its Diagram section, skip
+that doc (zero LLM calls). The v1.1 rollup_hashes entries coexist unchanged.
 """
 
 from __future__ import annotations
@@ -17,9 +22,10 @@ import hashlib
 import re
 
 from designdoc.hil import inline_comment
+from designdoc.io_utils import atomic_write
 from designdoc.mermaid.loop import generate_validated_mermaid, strip_fence
 from designdoc.mermaid.mmdc import preflight
-from designdoc.state import PipelineState, StageStatus
+from designdoc.state import PipelineState, StageStatus, state_lock
 
 STAGE_NAME = "mermaid"
 
@@ -52,8 +58,13 @@ async def run(
         rollup_key = f"mermaid:{rel}"
         input_hash = _hash_body(body)
 
-        # Skip when the body is unchanged AND the doc on disk still has
-        # its Diagram section (guard against manual strip).
+        # v1.2 within-stage skip: artifact_index check (survives mid-stage crash).
+        prior = state.artifact_index.get(rollup_key, {})
+        if prior.get("input_hash") == input_hash and input_hash != "" and "## Diagram" in text:
+            diagrams[rel] = _first_line_of_existing_diagram(text)
+            continue
+
+        # v1.1 cross-run skip: rollup_hashes check (unchanged).
         if state.rollup_hashes.get(rollup_key) == input_hash and "## Diagram" in text:
             diagrams[rel] = _first_line_of_existing_diagram(text)
             continue
@@ -79,9 +90,19 @@ async def run(
 
         # Write body (without any prior Diagram) plus the fresh section —
         # avoids stacking Diagram sections on re-run.
-        class_doc.write_text(body.rstrip() + section)
+        new_content = body.rstrip() + section
+        atomic_write(class_doc, new_content)
         diagrams[rel] = mermaid_src.splitlines()[0] if mermaid_src else ""
-        state.rollup_hashes[rollup_key] = input_hash
+
+        async with state_lock:
+            # v1.2 within-stage checkpoint: persist per-class mermaid entry.
+            state.artifact_index[rollup_key] = {
+                "path": rel,
+                "input_hash": input_hash,
+            }
+            # v1.1 cross-run skip coexists with v1.2 within-stage checkpoint.
+            state.rollup_hashes[rollup_key] = input_hash
+            state.save()
 
     state.stages[STAGE_NAME] = StageStatus.DONE
     state.current_stage = max(state.current_stage, 6)

--- a/src/designdoc/stages/s6_tech_debt.py
+++ b/src/designdoc/stages/s6_tech_debt.py
@@ -6,6 +6,12 @@ Perplexity + Context7 MCP access), and emits TECH_DEBT.md with one row per dep.
 v1.1 incremental: hash the stable (name, pinned, source) triple set of
 parsed deps. Skip the whole stage if state.rollup_hashes["tech_debt"]
 matches AND TECH_DEBT.md is still on disk.
+
+v1.2 within-stage checkpoint: after each dep is researched, persist
+artifact_index["dep:<name>"] with the per-dep input_hash and serialised row.
+On resume, any dep whose entry matches is skipped (zero LLM calls). The
+partial TECH_DEBT.md is rewritten atomically after every completed dep so a
+mid-stage crash leaves a consistent (partial) ledger on disk.
 """
 
 from __future__ import annotations
@@ -21,8 +27,9 @@ from designdoc.agents.tech_debt import (
     make_tech_debt_researcher,
 )
 from designdoc.index.manifests import Dep, parse_manifests
+from designdoc.io_utils import atomic_write
 from designdoc.loop import doer_checker_loop
-from designdoc.state import PipelineState, StageStatus
+from designdoc.state import PipelineState, StageStatus, state_lock
 
 STAGE_NAME = "tech_debt"
 OUTPUT_FILENAME = "TECH_DEBT.md"
@@ -46,7 +53,7 @@ async def run(
     input_hash = _hash_deps(deps)
     output_path = state.output_dir / OUTPUT_FILENAME
 
-    # Skip when deps unchanged AND the ledger is still on disk.
+    # v1.1 cross-run skip: whole-stage skip when dep manifest is unchanged.
     if state.rollup_hashes.get(ROLLUP_KEY) == input_hash and output_path.exists():
         state.stages[STAGE_NAME] = StageStatus.DONE
         state.current_stage = max(state.current_stage, 7)
@@ -58,7 +65,33 @@ async def run(
 
     sem = asyncio.Semaphore(max(1, parallelism))
 
-    async def _one(dep):
+    # Pre-populate rows from any artifact_index entries written by a prior
+    # (possibly crashed) run of this stage.  Key = dep name; value = row dict.
+    # The skip gate requires both a matching input_hash AND the output file
+    # to exist — if TECH_DEBT.md was deleted the checkpoint is stale.
+    rows: dict[str, dict] = {}
+    for dep in deps:
+        dep_input_hash = _hash_dep(dep)
+        artifact_id = f"dep:{dep.name}"
+        prior = state.artifact_index.get(artifact_id, {})
+        if (
+            prior.get("input_hash") == dep_input_hash
+            and dep_input_hash != ""
+            and output_path.exists()
+        ):
+            stored_row = prior.get("row")
+            if stored_row:
+                try:
+                    rows[dep.name] = json.loads(stored_row)
+                    continue
+                except (json.JSONDecodeError, TypeError):
+                    pass
+        # Not yet checkpointed — will be processed below.
+
+    to_process = [dep for dep in deps if dep.name not in rows]
+
+    async def _one(dep: Dep) -> None:
+        dep_input_hash = _hash_dep(dep)
         async with sem:
             doer_prompt = build_researcher_prompt(dep.name, dep.pinned)
 
@@ -75,16 +108,33 @@ async def run(
                 hil_sink=state.hil_issues,
                 stage_name=STAGE_NAME,
             )
-            return _parse_report(result.text, dep, disputed=result.status != "pass")
+            row = _parse_report(result.text, dep, disputed=result.status != "pass")
 
-    rows: list[dict] = list(await asyncio.gather(*[_one(dep) for dep in deps]))
+        async with state_lock:
+            rows[dep.name] = row
+            # Rewrite partial ledger atomically so a crash leaves a consistent file.
+            ordered_rows = [rows[d.name] for d in deps if d.name in rows]
+            atomic_write(output_path, _render_markdown(ordered_rows))
+            # v1.2 within-stage checkpoint: persist per-dep entry with row data.
+            state.artifact_index[f"dep:{dep.name}"] = {
+                "path": OUTPUT_FILENAME,
+                "input_hash": dep_input_hash,
+                "row": json.dumps(row),
+            }
+            state.save()
 
-    output_path.write_text(_render_markdown(rows))
-    state.rollup_hashes[ROLLUP_KEY] = input_hash
-    state.stages[STAGE_NAME] = StageStatus.DONE
-    state.current_stage = max(state.current_stage, 7)
-    state.save()
-    return rows
+    await asyncio.gather(*[_one(dep) for dep in to_process])
+
+    # Final atomic write with all deps in manifest order.
+    final_rows = [rows[dep.name] for dep in deps if dep.name in rows]
+    async with state_lock:
+        atomic_write(output_path, _render_markdown(final_rows))
+        # v1.1 cross-run skip coexists with v1.2 within-stage checkpoint.
+        state.rollup_hashes[ROLLUP_KEY] = input_hash
+        state.stages[STAGE_NAME] = StageStatus.DONE
+        state.current_stage = max(state.current_stage, 7)
+        state.save()
+    return final_rows
 
 
 def _hash_deps(deps: list[Dep]) -> str:
@@ -97,6 +147,18 @@ def _hash_deps(deps: list[Dep]) -> str:
         h.update(b"\0")
         h.update(dep.source.encode("utf-8"))
         h.update(b"\n")
+    return h.hexdigest()
+
+
+def _hash_dep(dep: Dep) -> str:
+    """SHA1 of a single dep's (name, pinned, source) triple."""
+    h = hashlib.sha1()
+    h.update(dep.name.encode("utf-8"))
+    h.update(b"\0")
+    h.update(dep.pinned.encode("utf-8"))
+    h.update(b"\0")
+    h.update(dep.source.encode("utf-8"))
+    h.update(b"\n")
     return h.hexdigest()
 
 

--- a/src/designdoc/state.py
+++ b/src/designdoc/state.py
@@ -7,6 +7,7 @@ crashed run picks-up-where-it-stopped.
 
 from __future__ import annotations
 
+import asyncio
 import json
 from dataclasses import asdict, dataclass, field
 from enum import StrEnum
@@ -31,15 +32,17 @@ class PipelineState:
     stages: dict[str, StageStatus] = field(default_factory=dict)
     total_retries: int = 0
     hil_issues: list[dict] = field(default_factory=list)
-    artifact_index: dict[str, str] = field(default_factory=dict)
+    # v1.2: each artifact_index entry carries the output path AND the SHA1
+    # of its inputs. On resume, an artifact is skipped only if the current
+    # input_hash matches the recorded one AND the output file exists.
+    artifact_index: dict[str, dict[str, str]] = field(default_factory=dict)
     # prev_hashes: SHA1 map from the last SUCCESSFUL run (seeded by Stage 8).
     # Incremental stages compare current Stage-0 hashes against this to
     # decide which source files need re-analysis.
     prev_hashes: dict[str, str] = field(default_factory=dict)
     # rollup_hashes: per-artifact SHA1 of a stage's INPUTS, keyed by
-    # artifact_id (e.g. "package:payments", "mermaid:StripeGateway",
-    # "system:rollup"). Lets rollup stages detect when their upstream
-    # hasn't changed since the last successful regeneration.
+    # artifact_id. Legacy v1.1 structure retained for cross-run skip logic
+    # outside of artifact_index (e.g. stage7 system rollup).
     rollup_hashes: dict[str, str] = field(default_factory=dict)
 
     @property
@@ -55,12 +58,7 @@ class PipelineState:
         self.state_path.write_text(json.dumps(data, indent=2))
 
     def unchanged_paths(self, current_hashes: dict[str, str]) -> set[str]:
-        """Return relative paths whose current hash matches prev_hashes.
-
-        A path not in prev_hashes is NEVER unchanged (first run or newly
-        added file). A path in prev_hashes but absent from current_hashes is
-        treated as deleted — also not unchanged.
-        """
+        """Return relative paths whose current hash matches prev_hashes."""
         return {
             path
             for path, current_hash in current_hashes.items()
@@ -79,8 +77,27 @@ class PipelineState:
                 stages={k: StageStatus(v) for k, v in d["stages"].items()},
                 total_retries=d["total_retries"],
                 hil_issues=d["hil_issues"],
-                artifact_index=d["artifact_index"],
+                artifact_index=_migrate_artifact_index(d.get("artifact_index", {})),
                 prev_hashes=d.get("prev_hashes", {}),
                 rollup_hashes=d.get("rollup_hashes", {}),
             )
         return cls(target_repo=target_repo, output_dir=output_dir)
+
+
+def _migrate_artifact_index(raw: dict) -> dict[str, dict[str, str]]:
+    """v1.1 stored values as strings; v1.2 stores dicts with path+input_hash.
+
+    Empty input_hash never matches a real SHA1 -> stage reprocesses, which
+    is the same as old behavior. Safe migration, no data loss."""
+    migrated: dict[str, dict[str, str]] = {}
+    for key, value in raw.items():
+        if isinstance(value, str):
+            migrated[key] = {"path": value, "input_hash": ""}
+        else:
+            migrated[key] = dict(value)
+    return migrated
+
+
+# Module-level lock so concurrent asyncio gather-children serialize their
+# JSON rewrites (not their LLM calls). Acquired ONLY around save().
+state_lock = asyncio.Lock()

--- a/src/designdoc/state.py
+++ b/src/designdoc/state.py
@@ -50,12 +50,14 @@ class PipelineState:
         return self.output_dir / STATE_FILENAME
 
     def save(self) -> None:
+        from designdoc.io_utils import atomic_write
+
         self.output_dir.mkdir(parents=True, exist_ok=True)
         data = asdict(self)
         data["target_repo"] = str(self.target_repo)
         data["output_dir"] = str(self.output_dir)
         data["stages"] = {k: str(v) for k, v in self.stages.items()}
-        self.state_path.write_text(json.dumps(data, indent=2))
+        atomic_write(self.state_path, json.dumps(data, indent=2))
 
     def unchanged_paths(self, current_hashes: dict[str, str]) -> set[str]:
         """Return relative paths whose current hash matches prev_hashes."""

--- a/src/designdoc/state.py
+++ b/src/designdoc/state.py
@@ -44,6 +44,10 @@ class PipelineState:
     # artifact_id. Legacy v1.1 structure retained for cross-run skip logic
     # outside of artifact_index (e.g. stage7 system rollup).
     rollup_hashes: dict[str, str] = field(default_factory=dict)
+    # Set True when orchestrator exits cleanly because a stage raised
+    # BudgetExceededError. CLI checks this flag to print the resume message
+    # and exit 0. Cleared on successful rerun with a new --budget value.
+    halted_on_budget: bool = False
 
     @property
     def state_path(self) -> Path:
@@ -82,6 +86,7 @@ class PipelineState:
                 artifact_index=_migrate_artifact_index(d.get("artifact_index", {})),
                 prev_hashes=d.get("prev_hashes", {}),
                 rollup_hashes=d.get("rollup_hashes", {}),
+                halted_on_budget=d.get("halted_on_budget", False),
             )
         return cls(target_repo=target_repo, output_dir=output_dir)
 

--- a/tests/integration/test_budget_halt.py
+++ b/tests/integration/test_budget_halt.py
@@ -1,0 +1,61 @@
+"""Graceful budget halt: mid-stage cap exit 0, resume --budget picks up."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from designdoc.budget import BudgetExceededError, CostAccumulator
+from designdoc.orchestrator import Orchestrator, StageEntry
+from designdoc.state import PipelineState, StageStatus
+
+
+class _AlwaysBudget:
+    """Stage that immediately raises BudgetExceededError."""
+
+    async def run(self, **_kwargs) -> None:
+        raise BudgetExceededError("stub: cap exceeded")
+
+
+@pytest.mark.anyio
+async def test_orchestrator_catches_budget_and_returns_halted(tmp_path: Path) -> None:
+    output = tmp_path / "out"
+    output.mkdir()
+    state = PipelineState(target_repo=tmp_path, output_dir=output)
+    budget = CostAccumulator(cap_usd=1.0, path=output / ".designdoc-budget.json")
+    stage = _AlwaysBudget()
+
+    orch = Orchestrator(
+        state=state,
+        runner=None,
+        budget=budget,
+        skip_stages={"mermaid"},
+        stages=[StageEntry("fake", stage.run, needs_runner=False)],
+    )
+    # Instead of raising, the orchestrator returns None and marks FAILED.
+    await orch.run()
+    assert state.stages["fake"] == StageStatus.FAILED
+    assert state.halted_on_budget is True
+
+
+@pytest.mark.anyio
+async def test_orchestrator_completed_has_halted_on_budget_false(tmp_path: Path) -> None:
+    output = tmp_path / "out"
+    output.mkdir()
+    state = PipelineState(target_repo=tmp_path, output_dir=output)
+    budget = CostAccumulator(cap_usd=1.0, path=output / ".designdoc-budget.json")
+
+    class _Noop:
+        async def run(self, **_kwargs) -> None:
+            return
+
+    orch = Orchestrator(
+        state=state,
+        runner=None,
+        budget=budget,
+        skip_stages={"mermaid"},
+        stages=[StageEntry("noop", _Noop().run, needs_runner=False)],
+    )
+    await orch.run()
+    assert state.halted_on_budget is False

--- a/tests/integration/test_orchestrator_checkpoint_logs.py
+++ b/tests/integration/test_orchestrator_checkpoint_logs.py
@@ -1,0 +1,76 @@
+"""Orchestrator log lines surface checkpoint counts per stage."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import pytest
+
+from designdoc.budget import CostAccumulator
+from designdoc.orchestrator import Orchestrator, StageEntry
+from designdoc.state import PipelineState
+
+
+@pytest.mark.anyio
+async def test_stage_log_includes_checkpoint_counts(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    output = tmp_path / "out"
+    output.mkdir()
+    state = PipelineState(target_repo=tmp_path, output_dir=output)
+    # Seed 3 checkpointed class_docs artifacts using the real key shape
+    # Stage 3 writes: "<path>::<class_name>" (no prefix).
+    for i in range(3):
+        state.artifact_index[f"foo.py::C{i}"] = {
+            "path": f"x/C{i}.md",
+            "input_hash": f"h{i}",
+        }
+    budget = CostAccumulator(cap_usd=10.0, path=output / ".designdoc-budget.json")
+
+    async def fake_stage(**_kwargs):
+        return None
+
+    orch = Orchestrator(
+        state=state,
+        runner=None,
+        budget=budget,
+        skip_stages={"mermaid"},
+        stages=[StageEntry("class_docs", fake_stage, needs_runner=False)],
+    )
+    with caplog.at_level(logging.INFO):
+        await orch.run()
+
+    matching = [r.getMessage() for r in caplog.records if "class_docs" in r.getMessage()]
+    starting = next((m for m in matching if "starting" in m or "checkpointed" in m), None)
+    assert starting is not None, matching
+    assert "3" in starting
+
+
+@pytest.mark.anyio
+async def test_stage_log_plain_starting_when_no_prior_checkpoints(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Stages with no prior artifacts keep the legacy "starting" line intact."""
+    output = tmp_path / "out"
+    output.mkdir()
+    state = PipelineState(target_repo=tmp_path, output_dir=output)
+    budget = CostAccumulator(cap_usd=10.0, path=output / ".designdoc-budget.json")
+
+    async def fake_stage(**_kwargs):
+        return None
+
+    orch = Orchestrator(
+        state=state,
+        runner=None,
+        budget=budget,
+        skip_stages={"mermaid"},
+        stages=[StageEntry("file_analysis", fake_stage, needs_runner=False)],
+    )
+    with caplog.at_level(logging.INFO):
+        await orch.run()
+
+    matching = [r.getMessage() for r in caplog.records if "file_analysis" in r.getMessage()]
+    starting = next((m for m in matching if "starting" in m), None)
+    assert starting is not None, matching
+    assert "checkpointed" not in starting

--- a/tests/integration/test_resume.py
+++ b/tests/integration/test_resume.py
@@ -142,21 +142,21 @@ async def test_resume_skips_completed_stages(tmp_path: Path):
 async def test_budget_exceeded_halts_pipeline(tmp_path: Path):
     """Set cap to $0 and verify the first LLM-using stage halts cleanly.
 
-    The stage that fails must be marked FAILED in state, budget must persist,
-    and subsequent stages must NOT have run.
+    v1.2 behavior: orchestrator returns (does not raise). state.halted_on_budget
+    is True, the stage is marked FAILED, budget is persisted, and later stages
+    have not run.
     """
     output = tmp_path / "design"
     state = PipelineState.load_or_new(output_dir=output, target_repo=TINY_REPO)
     budget = CostAccumulator(cap_usd=0.0001, path=output / ".designdoc-budget.json")
     runner = ClaudeSDKRunner(budget=budget, sdk=_RecordingSDK())
 
-    from designdoc.budget import BudgetExceededError
-
     # Skip mmdc preflight for this test — we're testing budget halt, not mmdc
     orchestrator = Orchestrator(state=state, runner=runner, budget=budget, skip_stages={"mermaid"})
-    with pytest.raises(BudgetExceededError):
-        await orchestrator.run()
+    # No raise: orchestrator halts gracefully and persists halt flag.
+    await orchestrator.run()
 
+    assert state.halted_on_budget is True
     # Stages 0 and 1 are LLM-free and should still complete
     assert state.stages["discover"] == StageStatus.DONE
     assert state.stages["index"] == StageStatus.DONE

--- a/tests/integration/test_stage2_resume.py
+++ b/tests/integration/test_stage2_resume.py
@@ -1,0 +1,132 @@
+"""Stage 2 within-stage resume: mid-stage raise + rerun = no duplicate LLM calls."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from designdoc.budget import CostAccumulator
+from designdoc.runner import ClaudeSDKRunner
+from designdoc.stages import s1_index, s2_file_analysis
+from designdoc.stages.s0_discover import OUTPUT_FILENAME as STAGE0_FILENAME
+from designdoc.state import PipelineState
+
+
+def _seed_stage0_and_stage1(state: PipelineState, files: dict[str, str]) -> None:
+    """Write stage0_discovery.json (hashes) and stage1 signatures.json."""
+    hashes = {p: hashlib.sha1(c.encode()).hexdigest() for p, c in files.items()}
+    (state.output_dir / STAGE0_FILENAME).write_text(
+        json.dumps({"hashes": hashes, "languages": {"python": list(files)}})
+    )
+    sigs = [
+        {"path": p, "classes": [], "functions": [], "imports": [], "parse_error": None}
+        for p in files
+    ]
+    (state.output_dir / s1_index.OUTPUT_FILENAME).write_text(json.dumps(sigs))
+
+
+def _valid_summary_json(n: int = 0) -> str:
+    return json.dumps(
+        {
+            "purpose": f"stub #{n}",
+            "key_types": [],
+            "key_functions": [],
+            "external_deps": [],
+            "notes": "",
+        }
+    )
+
+
+class _CountingFakeSDK:
+    """FakeSDK that counts calls and returns a valid FileSummary JSON."""
+
+    def __init__(self) -> None:
+        self.call_count: int = 0
+
+    async def query(self, *, prompt: str, options: dict) -> dict:
+        self.call_count += 1
+        return {
+            "text": _valid_summary_json(self.call_count),
+            "usage": {"input_tokens": 10, "output_tokens": 20, "cost_usd": 0.0},
+        }
+
+
+class _CrashAfterOneFakeSDK:
+    """FakeSDK that succeeds once then raises RuntimeError to simulate a crash."""
+
+    def __init__(self) -> None:
+        self.call_count: int = 0
+
+    async def query(self, *, prompt: str, options: dict) -> dict:
+        self.call_count += 1
+        if self.call_count == 2:
+            raise RuntimeError("simulated mid-stage crash")
+        return {
+            "text": _valid_summary_json(self.call_count),
+            "usage": {"input_tokens": 10, "output_tokens": 20, "cost_usd": 0.0},
+        }
+
+
+def _make_runner(sdk) -> ClaudeSDKRunner:
+    return ClaudeSDKRunner(budget=CostAccumulator(cap_usd=10.0), sdk=sdk)
+
+
+@pytest.mark.anyio("asyncio")
+async def test_stage2_checkpoints_after_each_file(tmp_path: Path) -> None:
+    output = tmp_path / "out"
+    output.mkdir()
+    state = PipelineState(target_repo=tmp_path, output_dir=output)
+    _seed_stage0_and_stage1(state, {"a.py": "print(1)", "b.py": "print(2)"})
+
+    sdk = _CountingFakeSDK()
+    await s2_file_analysis.run(state=state, runner=_make_runner(sdk), parallelism=1)
+
+    # Both files have artifact_index entries, each with a non-empty input_hash.
+    assert "file:a.py" in state.artifact_index
+    assert "file:b.py" in state.artifact_index
+    assert state.artifact_index["file:a.py"]["input_hash"] != ""
+
+
+@pytest.mark.anyio("asyncio")
+async def test_stage2_rerun_skips_checkpointed_files(tmp_path: Path) -> None:
+    output = tmp_path / "out"
+    output.mkdir()
+    state = PipelineState(target_repo=tmp_path, output_dir=output)
+    _seed_stage0_and_stage1(state, {"a.py": "print(1)", "b.py": "print(2)"})
+
+    # First run: both files processed.
+    sdk1 = _CountingFakeSDK()
+    await s2_file_analysis.run(state=state, runner=_make_runner(sdk1), parallelism=1)
+    assert sdk1.call_count == 2
+
+    # Reload state (simulates process death + rerun).
+    state2 = PipelineState.load_or_new(output_dir=output, target_repo=tmp_path)
+    sdk2 = _CountingFakeSDK()
+    await s2_file_analysis.run(state=state2, runner=_make_runner(sdk2), parallelism=1)
+    # No LLM calls on the rerun — everything already checkpointed.
+    assert sdk2.call_count == 0
+
+
+@pytest.mark.anyio("asyncio")
+async def test_stage2_mid_stage_crash_resumes_cleanly(tmp_path: Path) -> None:
+    """Simulate SIGKILL after 1 of 2 files: re-run processes ONLY the remaining file."""
+    output = tmp_path / "out"
+    output.mkdir()
+    state = PipelineState(target_repo=tmp_path, output_dir=output)
+    _seed_stage0_and_stage1(state, {"a.py": "print(1)", "b.py": "print(2)"})
+
+    crash_sdk = _CrashAfterOneFakeSDK()
+    with pytest.raises(RuntimeError, match="simulated mid-stage crash"):
+        await s2_file_analysis.run(state=state, runner=_make_runner(crash_sdk), parallelism=1)
+
+    # One file got checkpointed before the crash.
+    assert len(state.artifact_index) == 1
+
+    # Reload + re-run with a clean SDK: only the un-checkpointed file fires.
+    state2 = PipelineState.load_or_new(output_dir=output, target_repo=tmp_path)
+    clean_sdk = _CountingFakeSDK()
+    await s2_file_analysis.run(state=state2, runner=_make_runner(clean_sdk), parallelism=1)
+    assert clean_sdk.call_count == 1

--- a/tests/integration/test_stage3_resume.py
+++ b/tests/integration/test_stage3_resume.py
@@ -1,0 +1,90 @@
+"""Stage 3 within-stage resume: per-class checkpoint survives mid-stage crash."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from designdoc.budget import CostAccumulator
+from designdoc.runner import ClaudeSDKRunner
+from designdoc.stages import s1_index, s3_class_docs
+from designdoc.stages.s0_discover import OUTPUT_FILENAME as STAGE0_FILENAME
+from designdoc.state import PipelineState
+
+
+def _seed(state: PipelineState, classes_per_file: dict[str, list[str]]) -> None:
+    """Write stage0 hashes and stage1 signatures with the given classes."""
+    hashes = {path: hashlib.sha1(f"src:{path}".encode()).hexdigest() for path in classes_per_file}
+    (state.output_dir / STAGE0_FILENAME).write_text(
+        json.dumps({"hashes": hashes, "languages": {"python": list(classes_per_file)}})
+    )
+    sigs = [
+        {
+            "path": path,
+            "classes": [{"name": cls, "methods": [], "bases": []} for cls in classes],
+            "functions": [],
+            "imports": [],
+            "parse_error": None,
+        }
+        for path, classes in classes_per_file.items()
+    ]
+    (state.output_dir / s1_index.OUTPUT_FILENAME).write_text(json.dumps(sigs))
+
+
+class _FakeSDK:
+    """Fake SDK that returns valid doer/checker responses and counts calls."""
+
+    def __init__(self) -> None:
+        self.call_count: int = 0
+
+    async def query(self, *, prompt: str, options: dict) -> dict:
+        self.call_count += 1
+        system = options.get("system_prompt") or ""
+        if "doc-quality-checker" in system or "documentation QA" in system:
+            text = json.dumps({"verdict": "pass", "reasoning": "stub"})
+        else:
+            text = "# Stub class doc\n\nplaceholder"
+        return {
+            "text": text,
+            "usage": {"input_tokens": 10, "output_tokens": 20, "cost_usd": 0.0},
+        }
+
+
+def _make_runner(sdk: _FakeSDK) -> ClaudeSDKRunner:
+    return ClaudeSDKRunner(budget=CostAccumulator(cap_usd=10.0), sdk=sdk)
+
+
+@pytest.mark.anyio("asyncio")
+async def test_stage3_checkpoints_per_class(tmp_path: Path) -> None:
+    output = tmp_path / "out"
+    output.mkdir()
+    state = PipelineState(target_repo=tmp_path, output_dir=output)
+    _seed(state, {"src/foo.py": ["A", "B"]})
+
+    sdk = _FakeSDK()
+    await s3_class_docs.run(state=state, runner=_make_runner(sdk), parallelism=1)
+
+    assert "src/foo.py::A" in state.artifact_index
+    assert "src/foo.py::B" in state.artifact_index
+    assert state.artifact_index["src/foo.py::A"]["input_hash"] != ""
+
+
+@pytest.mark.anyio("asyncio")
+async def test_stage3_rerun_skips_checkpointed_classes(tmp_path: Path) -> None:
+    output = tmp_path / "out"
+    output.mkdir()
+    state = PipelineState(target_repo=tmp_path, output_dir=output)
+    _seed(state, {"src/foo.py": ["A", "B"]})
+
+    sdk1 = _FakeSDK()
+    await s3_class_docs.run(state=state, runner=_make_runner(sdk1), parallelism=1)
+    first_call_count = sdk1.call_count
+    assert first_call_count > 0
+
+    state2 = PipelineState.load_or_new(output_dir=output, target_repo=tmp_path)
+    sdk2 = _FakeSDK()
+    await s3_class_docs.run(state=state2, runner=_make_runner(sdk2), parallelism=1)
+    assert sdk2.call_count == 0

--- a/tests/integration/test_stage4_resume.py
+++ b/tests/integration/test_stage4_resume.py
@@ -1,0 +1,134 @@
+"""Stage 4 within-stage resume: per-package checkpoint survives mid-stage crash."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from designdoc.budget import CostAccumulator
+from designdoc.runner import ClaudeSDKRunner
+from designdoc.stages import s4_package_rollups
+from designdoc.state import PipelineState
+
+
+class _CountingFakeSDK:
+    """Mirrors CountingFakeSDK from test_stage4_incremental; counts LLM calls."""
+
+    def __init__(self) -> None:
+        self.call_count: int = 0
+
+    async def query(self, *, prompt: str, options: dict) -> dict:
+        self.call_count += 1
+        system = options.get("system_prompt") or ""
+        if "package-level documentation writer" in system:
+            return {
+                "text": "## Overview\nStub package rollup.\n",
+                "usage": {"input_tokens": 20, "output_tokens": 40, "cost_usd": 0.002},
+            }
+        if "rollup-accuracy reviewer" in system:
+            return {
+                "text": json.dumps({"status": "pass", "summary": "ok"}),
+                "usage": {"input_tokens": 20, "output_tokens": 10, "cost_usd": 0.001},
+            }
+        raise AssertionError(f"unexpected system prompt: {system[:80]}")
+
+
+def _seed_class_docs(output: Path, pkg: str, classes: list[str]) -> None:
+    pkg_dir = output / "packages" / pkg / "classes"
+    pkg_dir.mkdir(parents=True, exist_ok=True)
+    for c in classes:
+        (pkg_dir / f"{c}.md").write_text(f"# {c}\n\nclass doc")
+
+
+def _make_runner(sdk: _CountingFakeSDK) -> ClaudeSDKRunner:
+    return ClaudeSDKRunner(budget=CostAccumulator(cap_usd=10.0), sdk=sdk)
+
+
+@pytest.mark.anyio("asyncio")
+async def test_stage4_checkpoints_per_package(tmp_path: Path) -> None:
+    """After a successful run, artifact_index has a 'package:<pkg>' entry
+    with a non-empty input_hash."""
+    output = tmp_path / "out"
+    output.mkdir()
+    state = PipelineState(target_repo=tmp_path, output_dir=output)
+    _seed_class_docs(output, "alpha", ["A1", "A2"])
+
+    sdk = _CountingFakeSDK()
+    await s4_package_rollups.run(state=state, runner=_make_runner(sdk))
+
+    assert "package:alpha" in state.artifact_index, (
+        "artifact_index should have an entry for 'package:alpha'"
+    )
+    entry = state.artifact_index["package:alpha"]
+    assert entry["input_hash"] != "", "input_hash must be non-empty"
+    assert "path" in entry, "entry must include a path"
+
+
+@pytest.mark.anyio("asyncio")
+async def test_stage4_rerun_skips_checkpointed_packages(tmp_path: Path) -> None:
+    """Two-run test: first produces package README + artifact_index entry;
+    second run with identical class-doc hashes should make ZERO LLM calls."""
+    output = tmp_path / "out"
+    output.mkdir()
+    state = PipelineState(target_repo=tmp_path, output_dir=output)
+    _seed_class_docs(output, "alpha", ["A1", "A2"])
+
+    # First run: LLM is called.
+    sdk1 = _CountingFakeSDK()
+    await s4_package_rollups.run(state=state, runner=_make_runner(sdk1))
+    first_call_count = sdk1.call_count
+    assert first_call_count > 0, "first run must make LLM calls"
+
+    # Reload state from disk (simulating a crash-resume).
+    state2 = PipelineState.load_or_new(output_dir=output, target_repo=tmp_path)
+
+    # Second run: class docs unchanged -> zero LLM calls.
+    sdk2 = _CountingFakeSDK()
+    await s4_package_rollups.run(state=state2, runner=_make_runner(sdk2))
+    assert sdk2.call_count == 0, (
+        f"unchanged packages made {sdk2.call_count} LLM calls on second run; expected 0"
+    )
+
+
+@pytest.mark.anyio("asyncio")
+async def test_stage4_partial_crash_resume(tmp_path: Path) -> None:
+    """Simulate a mid-stage crash: pre-populate artifact_index for one package,
+    verify that only the other package is processed on the next run."""
+    output = tmp_path / "out"
+    output.mkdir()
+    state = PipelineState(target_repo=tmp_path, output_dir=output)
+    _seed_class_docs(output, "alpha", ["A1"])
+    _seed_class_docs(output, "beta", ["B1"])
+
+    # Simulate alpha having been completed before crash:
+    # write its README and artifact_index + rollup_hashes entries manually.
+    alpha_readme = output / "packages" / "alpha" / "README.md"
+    alpha_readme.write_text("## Alpha\nPre-existing readme.\n")
+    # Compute what the hash would be so skip gate fires.
+    import hashlib
+
+    h = hashlib.sha1()
+    alpha_doc = "# A1\n\nclass doc"
+    h.update(b"A1\x00")
+    h.update(alpha_doc.encode("utf-8"))
+    h.update(b"\n")
+    alpha_hash = h.hexdigest()
+
+    state.artifact_index["package:alpha"] = {
+        "path": "packages/alpha/README.md",
+        "input_hash": alpha_hash,
+    }
+    state.rollup_hashes["package:alpha"] = alpha_hash
+    state.save()
+
+    # Now run: only beta should be processed.
+    sdk = _CountingFakeSDK()
+    written = await s4_package_rollups.run(state=state, runner=_make_runner(sdk))
+
+    assert "beta" in written, "beta package should have been processed"
+    assert "alpha" in written, "alpha package should appear in written (skipped)"
+    # Doer + checker = 2 calls for beta only.
+    assert sdk.call_count == 2, f"expected 2 LLM calls for beta only, got {sdk.call_count}"
+    assert "package:beta" in state.artifact_index

--- a/tests/integration/test_stage5_resume.py
+++ b/tests/integration/test_stage5_resume.py
@@ -1,0 +1,154 @@
+"""Stage 5 within-stage resume: per-class diagram checkpoint.
+
+Tests that artifact_index["mermaid:<rel>"] is written after a successful
+diagram generation, and that a second run with the same class-doc body makes
+zero LLM calls (the checkpoint fires).
+
+These tests use a FakeSDK (no real mmdc required for the checkpoint-only
+assertions) but are gated by requires_mmdc because the full mermaid loop
+always runs mmdc for validation.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from designdoc.budget import CostAccumulator
+from designdoc.runner import ClaudeSDKRunner
+from designdoc.stages import s5_mermaid
+from designdoc.state import PipelineState
+
+
+class _CountingFakeSDK:
+    """Counts LLM calls and returns valid mermaid + pass verdict."""
+
+    def __init__(self) -> None:
+        self.call_count: int = 0
+
+    async def query(self, *, prompt: str, options: dict) -> dict:
+        self.call_count += 1
+        system = options.get("system_prompt") or ""
+        if "mermaid diagram generator" in system:
+            return {
+                "text": "flowchart TD\n    A --> B\n",
+                "usage": {"input_tokens": 10, "output_tokens": 20, "cost_usd": 0.001},
+            }
+        if "mermaid-semantics reviewer" in system:
+            return {
+                "text": json.dumps({"status": "pass", "summary": "ok"}),
+                "usage": {"input_tokens": 10, "output_tokens": 5, "cost_usd": 0.0005},
+            }
+        raise AssertionError(f"unexpected system prompt: {system[:80]}")
+
+
+def _make_runner(sdk: _CountingFakeSDK) -> ClaudeSDKRunner:
+    return ClaudeSDKRunner(budget=CostAccumulator(cap_usd=5.0), sdk=sdk)
+
+
+def _seed_class_doc(output: Path, pkg: str, class_name: str, body: str) -> Path:
+    classes_dir = output / "packages" / pkg / "classes"
+    classes_dir.mkdir(parents=True, exist_ok=True)
+    doc = classes_dir / f"{class_name}.md"
+    doc.write_text(body)
+    return doc
+
+
+@pytest.mark.requires_mmdc
+@pytest.mark.anyio
+async def test_stage5_checkpoints_per_class_diagram(tmp_path: Path) -> None:
+    """After a successful run, artifact_index has a 'mermaid:<rel>' entry
+    with a non-empty input_hash."""
+    output = tmp_path / "out"
+    output.mkdir()
+    state = PipelineState(target_repo=tmp_path, output_dir=output)
+    _seed_class_doc(output, "alpha", "Foo", "# Foo\n\nclass doc\n")
+
+    sdk = _CountingFakeSDK()
+    await s5_mermaid.run(state=state, runner=_make_runner(sdk), skip_preflight=False)
+
+    rel = "packages/alpha/classes/Foo.md"
+    assert f"mermaid:{rel}" in state.artifact_index, (
+        "artifact_index must have an entry for the generated mermaid diagram"
+    )
+    entry = state.artifact_index[f"mermaid:{rel}"]
+    assert entry["input_hash"] != "", "input_hash must be non-empty"
+    assert entry["path"] == rel, "path must match the class doc relative path"
+
+
+@pytest.mark.requires_mmdc
+@pytest.mark.anyio
+async def test_stage5_rerun_skips_checkpointed_diagrams(tmp_path: Path) -> None:
+    """Two-run test: first run produces mermaid diagram + artifact_index entry;
+    second run with same class-doc body must make ZERO LLM calls."""
+    output = tmp_path / "out"
+    output.mkdir()
+    state = PipelineState(target_repo=tmp_path, output_dir=output)
+    _seed_class_doc(output, "payments", "Gateway", "# Gateway\n\npayment class\n")
+
+    # First run: LLM is called.
+    sdk1 = _CountingFakeSDK()
+    await s5_mermaid.run(state=state, runner=_make_runner(sdk1), skip_preflight=False)
+    assert sdk1.call_count > 0, "first run must make LLM calls"
+
+    # Verify artifact_index entry was written.
+    rel = "packages/payments/classes/Gateway.md"
+    assert f"mermaid:{rel}" in state.artifact_index
+    first_hash = state.artifact_index[f"mermaid:{rel}"]["input_hash"]
+    assert first_hash != ""
+
+    # Reload state from disk (simulating a crash-resume).
+    state2 = PipelineState.load_or_new(output_dir=output, target_repo=tmp_path)
+
+    # Second run: class doc body unchanged -> zero LLM calls.
+    sdk2 = _CountingFakeSDK()
+    await s5_mermaid.run(state=state2, runner=_make_runner(sdk2), skip_preflight=False)
+    assert sdk2.call_count == 0, (
+        f"unchanged class doc made {sdk2.call_count} LLM calls on second run; expected 0"
+    )
+
+
+@pytest.mark.requires_mmdc
+@pytest.mark.anyio
+async def test_stage5_partial_crash_resume(tmp_path: Path) -> None:
+    """Simulate a mid-stage crash: pre-populate artifact_index for one class doc,
+    verify that only the other class doc is processed on the next run."""
+    output = tmp_path / "out"
+    output.mkdir()
+    state = PipelineState(target_repo=tmp_path, output_dir=output)
+
+    foo_doc = _seed_class_doc(output, "alpha", "Foo", "# Foo\n\nfoo class\n")
+    _seed_class_doc(output, "alpha", "Bar", "# Bar\n\nbar class\n")
+
+    # Simulate Foo having been completed before crash: write its Diagram section
+    # and populate artifact_index + rollup_hashes.
+    import hashlib
+
+    foo_body = "# Foo\n\nfoo class\n"
+    foo_hash = hashlib.sha1(foo_body.encode("utf-8")).hexdigest()
+    foo_doc.write_text(
+        foo_body.rstrip() + "\n\n## Diagram\n\n```mermaid\nflowchart TD\n    A --> B\n```\n"
+    )
+
+    rel_foo = "packages/alpha/classes/Foo.md"
+    state.artifact_index[f"mermaid:{rel_foo}"] = {
+        "path": rel_foo,
+        "input_hash": foo_hash,
+    }
+    state.rollup_hashes[f"mermaid:{rel_foo}"] = foo_hash
+    state.save()
+
+    # Now run: only Bar should be processed (Foo is checkpointed).
+    sdk = _CountingFakeSDK()
+    diagrams = await s5_mermaid.run(state=state, runner=_make_runner(sdk), skip_preflight=False)
+
+    assert sdk.call_count > 0, "Bar must be processed (LLM calls expected)"
+    # 2 calls: doer + checker for Bar only
+    assert sdk.call_count == 2, f"expected 2 LLM calls for Bar only, got {sdk.call_count}"
+    rel_bar = "packages/alpha/classes/Bar.md"
+    assert f"mermaid:{rel_bar}" in state.artifact_index, "Bar must be checkpointed after processing"
+    # Foo should appear in diagrams (returned from skip path).
+    assert rel_foo in diagrams
+    assert rel_bar in diagrams

--- a/tests/integration/test_stage6_incremental.py
+++ b/tests/integration/test_stage6_incremental.py
@@ -86,8 +86,9 @@ async def test_added_dep_regenerates(tmp_path: Path):
     _seed_pyproject(tmp_path, ["requests>=2.31", "pydantic>=2.7"])
     fake = CountingFakeSDK()
     await _run_stage6(state, fake)
-    # Regeneration covers ALL deps — researcher + crossref per dep = 4 calls.
-    assert len(fake.calls) == 4, f"expected 4 calls for 2 deps, got {len(fake.calls)}"
+    # v1.2: requests is already checkpointed (unchanged), so only pydantic is
+    # researched — researcher + crossref = 2 calls for the new dep only.
+    assert len(fake.calls) == 2, f"expected 2 calls for new dep only, got {len(fake.calls)}"
 
 
 @pytest.mark.anyio
@@ -100,7 +101,11 @@ async def test_removed_dep_regenerates(tmp_path: Path):
     _seed_pyproject(tmp_path, ["requests>=2.31"])
     fake = CountingFakeSDK()
     await _run_stage6(state, fake)
-    assert len(fake.calls) == 2, "removed dep -> regenerate with remaining"
+    # v1.2: requests is already checkpointed and unchanged — zero LLM calls.
+    # The final TECH_DEBT.md is rewritten with only the remaining dep.
+    assert len(fake.calls) == 0, (
+        f"remaining unchanged dep should be skipped, got {len(fake.calls)} calls"
+    )
 
 
 @pytest.mark.anyio

--- a/tests/integration/test_stage6_resume.py
+++ b/tests/integration/test_stage6_resume.py
@@ -1,0 +1,178 @@
+"""Stage 6 within-stage resume: per-dep checkpoint survives mid-stage crash.
+
+Tests that:
+1. artifact_index["dep:<name>"] is written after each dep is researched.
+2. A second run with unchanged deps makes zero LLM calls (checkpoint fires).
+3. A simulated mid-stage crash (partial artifact_index) causes only the
+   un-checkpointed deps to be processed on the next run.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from designdoc.budget import CostAccumulator
+from designdoc.runner import ClaudeSDKRunner
+from designdoc.stages.s6_tech_debt import _hash_dep
+from designdoc.stages.s6_tech_debt import run as stage_tech_debt
+from designdoc.state import PipelineState
+
+
+class _CountingFakeSDK:
+    """Counts LLM calls and returns valid researcher + pass-verdict responses.
+
+    Extracts the dependency name from the prompt ("Dependency: <name>") so the
+    returned row carries the real dep name instead of a placeholder.
+    """
+
+    def __init__(self) -> None:
+        self.call_count: int = 0
+
+    async def query(self, *, prompt: str, options: dict) -> dict:
+        self.call_count += 1
+        system = options.get("system_prompt") or ""
+        # Extract dep name from prompt line "Dependency: <name>".
+        dep_name = "stub"
+        for line in prompt.splitlines():
+            if line.startswith("Dependency:"):
+                dep_name = line.split(":", 1)[1].strip()
+                break
+        if "tech-debt researcher" in system:
+            return {
+                "text": json.dumps(
+                    {
+                        "name": dep_name,
+                        "pinned": ">=1.0",
+                        "latest": "1.1",
+                        "status": "current",
+                        "cves": [],
+                        "recommended_action": "none",
+                        "sources": [],
+                    }
+                ),
+                "usage": {"input_tokens": 20, "output_tokens": 40, "cost_usd": 0.002},
+            }
+        if "cross-reference reviewer" in system:
+            return {
+                "text": json.dumps({"status": "pass", "summary": "ok"}),
+                "usage": {"input_tokens": 20, "output_tokens": 10, "cost_usd": 0.001},
+            }
+        raise AssertionError(f"unexpected system prompt: {system[:80]}")
+
+
+def _seed_pyproject(tmp_path: Path, deps: list[str]) -> None:
+    deps_toml = ",\n    ".join(f'"{d}"' for d in deps)
+    (tmp_path / "pyproject.toml").write_text(
+        f'[project]\nname = "x"\nversion = "0"\ndependencies = [\n    {deps_toml}\n]\n'
+    )
+
+
+def _make_runner(sdk: _CountingFakeSDK) -> ClaudeSDKRunner:
+    return ClaudeSDKRunner(budget=CostAccumulator(cap_usd=10.0), sdk=sdk)
+
+
+@pytest.mark.anyio
+async def test_stage6_checkpoints_per_dep(tmp_path: Path) -> None:
+    """After a successful run, artifact_index has 'dep:<name>' entries
+    with non-empty input_hash and serialised row data."""
+    _seed_pyproject(tmp_path, ["requests>=2.31"])
+    output = tmp_path / "design"
+    state = PipelineState.load_or_new(output_dir=output, target_repo=tmp_path)
+
+    sdk = _CountingFakeSDK()
+    await stage_tech_debt(state=state, runner=_make_runner(sdk))
+
+    assert "dep:requests" in state.artifact_index, (
+        "artifact_index must have an entry for 'dep:requests'"
+    )
+    entry = state.artifact_index["dep:requests"]
+    assert entry["input_hash"] != "", "input_hash must be non-empty"
+    assert entry["path"] == "TECH_DEBT.md", "path must point to TECH_DEBT.md"
+    assert "row" in entry, "entry must contain serialised row data"
+    row = json.loads(entry["row"])
+    assert "name" in row and "status" in row, "row must contain at least name and status"
+
+
+@pytest.mark.anyio
+async def test_stage6_rerun_skips_checkpointed_deps(tmp_path: Path) -> None:
+    """Two-run test: first run produces TECH_DEBT.md + artifact_index entries;
+    second run with same dep manifest must make ZERO LLM calls."""
+    _seed_pyproject(tmp_path, ["requests>=2.31"])
+    output = tmp_path / "design"
+    state = PipelineState.load_or_new(output_dir=output, target_repo=tmp_path)
+
+    # First run: LLM is called.
+    sdk1 = _CountingFakeSDK()
+    await stage_tech_debt(state=state, runner=_make_runner(sdk1))
+    assert sdk1.call_count > 0, "first run must make LLM calls"
+
+    # Verify artifact_index entry was written.
+    assert "dep:requests" in state.artifact_index
+    assert state.artifact_index["dep:requests"]["input_hash"] != ""
+
+    # Reload state from disk (simulating a crash-resume).
+    state2 = PipelineState.load_or_new(output_dir=output, target_repo=tmp_path)
+
+    # Second run: dep manifest unchanged -> zero LLM calls (checkpoint fires).
+    sdk2 = _CountingFakeSDK()
+    await stage_tech_debt(state=state2, runner=_make_runner(sdk2))
+    assert sdk2.call_count == 0, (
+        f"unchanged deps made {sdk2.call_count} LLM calls on second run; expected 0"
+    )
+
+
+@pytest.mark.anyio
+async def test_stage6_partial_crash_resume(tmp_path: Path) -> None:
+    """Simulate a mid-stage crash: pre-populate artifact_index for one dep,
+    verify that only the other dep is processed on the next run."""
+    from designdoc.index.manifests import Dep
+
+    _seed_pyproject(tmp_path, ["requests>=2.31", "pydantic>=2.7"])
+    output = tmp_path / "design"
+    output.mkdir(parents=True, exist_ok=True)
+    state = PipelineState.load_or_new(output_dir=output, target_repo=tmp_path)
+
+    # Simulate 'requests' having been completed before crash:
+    # manually compute its input_hash and plant it in artifact_index with a row.
+    requests_dep = Dep(name="requests", pinned=">=2.31", source="pyproject.toml")
+    req_hash = _hash_dep(requests_dep)
+    req_row = {
+        "name": "requests",
+        "pinned": ">=2.31",
+        "latest": "2.32",
+        "status": "current",
+        "cves": [],
+        "recommended_action": "none",
+        "sources": [],
+        "disputed": False,
+        "source_file": "pyproject.toml",
+    }
+    state.artifact_index["dep:requests"] = {
+        "path": "TECH_DEBT.md",
+        "input_hash": req_hash,
+        "row": json.dumps(req_row),
+    }
+    state.save()
+    # Simulate the partial TECH_DEBT.md that would have been written atomically
+    # after 'requests' completed before the crash.
+    from designdoc.stages.s6_tech_debt import _render_markdown
+
+    (output / "TECH_DEBT.md").write_text(_render_markdown([req_row]))
+
+    # Now run: only 'pydantic' should be processed.
+    sdk = _CountingFakeSDK()
+    rows = await stage_tech_debt(state=state, runner=_make_runner(sdk))
+
+    # Researcher + crossref = 2 calls for pydantic only.
+    assert sdk.call_count == 2, f"expected 2 LLM calls for pydantic only, got {sdk.call_count}"
+    assert len(rows) == 2, f"expected 2 rows (requests + pydantic), got {len(rows)}"
+    dep_names = {r["name"] for r in rows}
+    assert "requests" in dep_names, "'requests' row should be in final output (from checkpoint)"
+    assert "pydantic" in dep_names, "'pydantic' row should be in final output (freshly processed)"
+
+    # Both deps now checkpointed.
+    assert "dep:requests" in state.artifact_index
+    assert "dep:pydantic" in state.artifact_index

--- a/tests/integration/test_within_stage_resume_e2e.py
+++ b/tests/integration/test_within_stage_resume_e2e.py
@@ -1,0 +1,211 @@
+"""Within-stage resume e2e correctness.
+
+Validates the load-bearing invariant of v1.2: a pipeline halted mid-stage
+checkpoints the artifacts it finished and the resume run reuses them rather
+than regenerating. Uses the deterministic _RecordingSDK from
+test_resume.py so the correctness check is cheap and reproducible in CI.
+
+The proof of non-regeneration is a call count: halt+resume across two
+orchestrator invocations makes exactly the same total SDK calls as a
+single clean run. Any extra calls would mean the resume regenerated
+something the checkpoint already held.
+
+Note: this replaces the plan's original requires_api subprocess test, which
+would have relied on byte-identical output against the live Claude API —
+impossible with LLM non-determinism. The invariant we actually need
+(reuse-on-resume) is checked here with a deterministic fake.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from designdoc.budget import BUDGET_FILENAME, CostAccumulator
+from designdoc.config import Config
+from designdoc.orchestrator import Orchestrator
+from designdoc.runner import ClaudeSDKRunner
+from designdoc.state import PipelineState, StageStatus
+
+TINY_REPO = Path(__file__).parent.parent / "fixtures" / "tiny_repo"
+
+
+def _ok(obj: dict) -> dict:
+    return {
+        "text": json.dumps(obj),
+        "usage": {"input_tokens": 10, "output_tokens": 20, "cost_usd": 0.001},
+    }
+
+
+def _ok_text(text: str) -> dict:
+    return {
+        "text": text,
+        "usage": {"input_tokens": 10, "output_tokens": 20, "cost_usd": 0.001},
+    }
+
+
+class _RecordingSDK:
+    """Deterministic SDK fake — same prompt always yields same response.
+
+    Mirrors tests/integration/test_resume.py::_RecordingSDK. Duplicated rather
+    than imported because tests/ is not a Python package on pytest's path.
+    """
+
+    def __init__(self):
+        self.calls: list[str] = []
+
+    async def query(self, *, prompt: str, options: dict) -> dict:
+        system = options.get("system_prompt") or ""
+        self.calls.append(system[:60])
+        if "code-summary agent" in system:
+            return _ok(
+                {
+                    "purpose": "stub",
+                    "key_types": [],
+                    "key_functions": [],
+                    "external_deps": [],
+                    "notes": "",
+                }
+            )
+        if "design-documentation writer" in system:
+            return _ok_text("## Purpose\nStub.")
+        if "documentation QA reviewer" in system:
+            return _ok({"status": "pass", "summary": "ok"})
+        if "package-level documentation writer" in system:
+            return _ok_text("## Overview\nStub.")
+        if "rollup-accuracy reviewer" in system:
+            return _ok({"status": "pass", "summary": "ok"})
+        if "mermaid diagram generator" in system:
+            return _ok_text("flowchart TD\n    A --> B\n")
+        if "mermaid-semantics reviewer" in system:
+            return _ok({"status": "pass", "summary": "ok"})
+        if "tech-debt researcher" in system:
+            return _ok(
+                {
+                    "name": "requests",
+                    "pinned": ">=2.31",
+                    "latest": "2.32",
+                    "status": "current",
+                    "cves": [],
+                    "recommended_action": "none",
+                    "sources": [],
+                }
+            )
+        if "cross-reference reviewer" in system:
+            return _ok({"status": "pass", "summary": "ok"})
+        if "system design writer" in system:
+            return _ok_text(
+                "<<<SYSTEM_DESIGN>>>\n## Overview\nstub\n\n"
+                "<<<ARCHITECTURE>>>\n## Containers\n- cli\n"
+            )
+        if "system-design accuracy reviewer" in system:
+            return _ok({"status": "pass", "summary": "ok"})
+        raise AssertionError(f"unhandled agent: {system[:80]}")
+
+
+def _tree_hash(root: Path) -> str:
+    """SHA1 of sorted (relpath, content-sha1) pairs — excludes state files."""
+    entries = []
+    for p in sorted(root.rglob("*")):
+        if p.is_file() and not p.name.startswith(".designdoc-"):
+            content_sha = hashlib.sha1(p.read_bytes()).hexdigest()
+            entries.append(f"{p.relative_to(root)}:{content_sha}")
+    return hashlib.sha1("\n".join(entries).encode()).hexdigest()
+
+
+@pytest.mark.requires_mmdc
+@pytest.mark.anyio
+async def test_halt_and_resume_matches_clean_run(tmp_path: Path) -> None:
+    """Halt mid-Stage-3 via budget cap, resume, assert byte-identical output
+    AND no redundant SDK calls vs a clean cold run."""
+    # parallelism=1 so in-flight calls at budget-halt time are predictable —
+    # with the default parallelism=3 the halt can land after up-to-3 doers
+    # return, which fuzzes the expected SDK call count below.
+    serial_config = Config(parallelism=1)
+
+    # --- Clean baseline run ---
+    clean_out = tmp_path / "clean"
+    clean_state = PipelineState.load_or_new(output_dir=clean_out, target_repo=TINY_REPO)
+    clean_budget = CostAccumulator(cap_usd=5.0, path=clean_out / BUDGET_FILENAME)
+    clean_sdk = _RecordingSDK()
+    clean_runner = ClaudeSDKRunner(budget=clean_budget, sdk=clean_sdk)
+    await Orchestrator(
+        state=clean_state, runner=clean_runner, budget=clean_budget, config=serial_config
+    ).run()
+    clean_tree_hash = _tree_hash(clean_out)
+
+    # --- Halt + resume run ---
+    halt_out = tmp_path / "halt"
+    halt_state = PipelineState.load_or_new(output_dir=halt_out, target_repo=TINY_REPO)
+    # Cap tight enough to fail partway through Stage 3 (after Stage 2 completes
+    # and at least one class_doc has been checkpointed). tiny_repo has:
+    # - 5 files × 1 Stage 2 call = 5 calls ($0.005)
+    # - 3 classes × 2 Stage 3 calls = 6 calls ($0.006)
+    # Setting $0.0075 allows Stage 2 (5) + one full class doer+checker (2) + one
+    # more doer (1) = 8 calls, and the 9th (class 2 checker) triggers the halt.
+    # That leaves class 1 fully checkpointed, class 2 in-flight and discarded.
+    halt_budget = CostAccumulator(cap_usd=0.0075, path=halt_out / BUDGET_FILENAME)
+    halt_sdk = _RecordingSDK()
+    halt_runner = ClaudeSDKRunner(budget=halt_budget, sdk=halt_sdk)
+    await Orchestrator(
+        state=halt_state,
+        runner=halt_runner,
+        budget=halt_budget,
+        config=serial_config,
+    ).run()
+
+    # Verify we halted mid-Stage-3 (not before, not after).
+    assert halt_state.halted_on_budget is True
+    assert halt_state.stages.get("file_analysis") == StageStatus.DONE
+    assert halt_state.stages.get("class_docs") == StageStatus.FAILED
+    # Exactly one class doc got checkpointed — this is the artifact we prove is reused.
+    checkpointed_ids = [k for k in halt_state.artifact_index if "::" in k]
+    assert len(checkpointed_ids) == 1, (
+        f"expected exactly 1 class checkpoint at halt, got {checkpointed_ids}"
+    )
+    halt_call_snapshot = len(halt_sdk.calls)
+
+    # --- Resume run: raise cap, clear halt flag (mimics CLI --budget reset) ---
+    halt_state.halted_on_budget = False
+    resume_budget = CostAccumulator.load_or_new(cap_usd=5.0, path=halt_out / BUDGET_FILENAME)
+    resume_runner = ClaudeSDKRunner(budget=resume_budget, sdk=halt_sdk)  # same SDK
+    await Orchestrator(
+        state=halt_state, runner=resume_runner, budget=resume_budget, config=serial_config
+    ).run()
+
+    # --- Assertions ---
+    # Resume-phase Stage 3 doer calls is the load-bearing invariant:
+    # tiny_repo has 3 classes, halt checkpointed class 1. If within-stage
+    # resume works, resume should make exactly 2 doer calls (class 2 + class 3).
+    # If the checkpointed class 1 were regenerated, we'd see 3.
+    resume_only_calls = halt_sdk.calls[halt_call_snapshot:]
+    resume_stage3_doer_count = sum(
+        1 for c in resume_only_calls if "design-documentation writer" in c
+    )
+    assert resume_stage3_doer_count == 2, (
+        f"expected 2 Stage 3 doer calls on resume (class 2 + class 3), got "
+        f"{resume_stage3_doer_count}. More implies checkpointed class 1 was regenerated."
+    )
+
+    # Full pipeline completed after resume.
+    for stage_name in (
+        "discover",
+        "index",
+        "file_analysis",
+        "class_docs",
+        "package_rollups",
+        "mermaid",
+        "tech_debt",
+        "system_rollup",
+        "finalize",
+    ):
+        assert halt_state.stages.get(stage_name) == StageStatus.DONE, (
+            f"stage {stage_name} not DONE after resume"
+        )
+
+    # Final output tree is byte-identical to a clean cold run — strong high-level
+    # smoke that the pipeline is deterministic given the fake SDK.
+    assert _tree_hash(halt_out) == clean_tree_hash

--- a/tests/unit/test_io_utils.py
+++ b/tests/unit/test_io_utils.py
@@ -1,0 +1,44 @@
+"""Atomic write helper: tempfile-and-rename semantics under POSIX."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from designdoc.io_utils import atomic_write
+
+
+def test_atomic_write_creates_target(tmp_path: Path) -> None:
+    target = tmp_path / "out.md"
+    atomic_write(target, "hello")
+    assert target.read_text() == "hello"
+
+
+def test_atomic_write_overwrites_existing(tmp_path: Path) -> None:
+    target = tmp_path / "out.md"
+    target.write_text("old")
+    atomic_write(target, "new")
+    assert target.read_text() == "new"
+
+
+def test_atomic_write_leaves_no_tmp_on_success(tmp_path: Path) -> None:
+    target = tmp_path / "out.md"
+    atomic_write(target, "hello")
+    tmp_siblings = [p for p in tmp_path.iterdir() if p.name.endswith(".tmp")]
+    assert tmp_siblings == []
+
+
+def test_atomic_write_requires_parent_directory(tmp_path: Path) -> None:
+    target = tmp_path / "missing" / "out.md"
+    with pytest.raises(FileNotFoundError):
+        atomic_write(target, "hello")
+
+
+def test_atomic_write_tmp_is_gone_after_replace(tmp_path: Path) -> None:
+    """The .tmp file must not persist after the rename."""
+    target = tmp_path / "out.md"
+    atomic_write(target, "hello")
+    tmp = target.with_suffix(target.suffix + ".tmp")
+    assert not tmp.exists()
+    assert target.exists()

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -26,7 +26,10 @@ def test_roundtrip_preserves_all_fields(tmp_path: Path):
     s.current_stage = 1
     s.total_retries = 4
     s.hil_issues.append({"id": "HIL-001", "severity": "major"})
-    s.artifact_index["pkg.ClassA"] = "packages/pkg/classes/ClassA.md"
+    s.artifact_index["pkg.ClassA"] = {
+        "path": "packages/pkg/classes/ClassA.md",
+        "input_hash": "deadbeef",
+    }
     s.save()
 
     s2 = PipelineState.load_or_new(output_dir=tmp_path, target_repo=Path("/x"))
@@ -35,7 +38,12 @@ def test_roundtrip_preserves_all_fields(tmp_path: Path):
     assert s2.current_stage == 1
     assert s2.total_retries == 4
     assert s2.hil_issues == [{"id": "HIL-001", "severity": "major"}]
-    assert s2.artifact_index == {"pkg.ClassA": "packages/pkg/classes/ClassA.md"}
+    assert s2.artifact_index == {
+        "pkg.ClassA": {
+            "path": "packages/pkg/classes/ClassA.md",
+            "input_hash": "deadbeef",
+        }
+    }
 
 
 def test_save_creates_output_dir_if_missing(tmp_path: Path):

--- a/tests/unit/test_state_backcompat.py
+++ b/tests/unit/test_state_backcompat.py
@@ -1,0 +1,72 @@
+"""artifact_index shape change + backcompat loader.
+
+v1.2 moves artifact_index from {id: str_path} to {id: {"path": ..., "input_hash": ...}}.
+Old state files still round-trip: the loader migrates string values to dict
+form with empty input_hash, which will never match current hashes -> the
+stage will reprocess, which is safe and matches pre-v1.2 behavior.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from designdoc.state import STATE_FILENAME, PipelineState
+
+
+def test_new_shape_round_trips(tmp_path: Path) -> None:
+    output = tmp_path / "out"
+    output.mkdir()
+    s = PipelineState(target_repo=tmp_path, output_dir=output)
+    s.artifact_index["class:Foo"] = {"path": "packages/x/Foo.md", "input_hash": "abc"}
+    s.save()
+
+    loaded = PipelineState.load_or_new(output_dir=output, target_repo=tmp_path)
+    assert loaded.artifact_index == {
+        "class:Foo": {"path": "packages/x/Foo.md", "input_hash": "abc"}
+    }
+
+
+def test_backcompat_loads_old_string_shape(tmp_path: Path) -> None:
+    """An old (v1.1) state file with string-valued artifact_index loads without error."""
+    output = tmp_path / "out"
+    output.mkdir()
+    old_state = {
+        "target_repo": str(tmp_path),
+        "output_dir": str(output),
+        "current_stage": 3,
+        "stages": {"class_docs": "done"},
+        "total_retries": 0,
+        "hil_issues": [],
+        "artifact_index": {"class:Foo": "packages/x/Foo.md"},
+        "prev_hashes": {},
+        "rollup_hashes": {},
+    }
+    (output / STATE_FILENAME).write_text(json.dumps(old_state))
+
+    loaded = PipelineState.load_or_new(output_dir=output, target_repo=tmp_path)
+    assert loaded.artifact_index == {"class:Foo": {"path": "packages/x/Foo.md", "input_hash": ""}}
+
+
+def test_backcompat_migrated_values_force_reprocess(tmp_path: Path) -> None:
+    """Empty input_hash will never equal a real SHA1 — skip-check fails, stage reprocesses."""
+    output = tmp_path / "out"
+    output.mkdir()
+    old_state = {
+        "target_repo": str(tmp_path),
+        "output_dir": str(output),
+        "current_stage": 0,
+        "stages": {},
+        "total_retries": 0,
+        "hil_issues": [],
+        "artifact_index": {"class:Foo": "packages/x/Foo.md"},
+        "prev_hashes": {},
+        "rollup_hashes": {},
+    }
+    (output / STATE_FILENAME).write_text(json.dumps(old_state))
+
+    loaded = PipelineState.load_or_new(output_dir=output, target_repo=tmp_path)
+    entry = loaded.artifact_index["class:Foo"]
+    # Pretend the current hash of the input is some real SHA.
+    current_input_hash = "a" * 40
+    assert entry["input_hash"] != current_input_hash

--- a/tests/unit/test_state_lock.py
+++ b/tests/unit/test_state_lock.py
@@ -1,0 +1,63 @@
+"""Concurrent save safety and atomic state.json writes."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from designdoc.state import PipelineState, state_lock
+
+
+@pytest.mark.anyio("asyncio")
+async def test_concurrent_saves_under_lock_preserve_last_write(tmp_path: Path) -> None:
+    """50 concurrent mutators + saves; final state contains all 50 entries."""
+    output = tmp_path / "out"
+    output.mkdir()
+    s = PipelineState(target_repo=tmp_path, output_dir=output)
+
+    async def mutator(i: int) -> None:
+        async with state_lock:
+            s.artifact_index[f"id-{i}"] = {"path": f"p{i}", "input_hash": f"h{i}"}
+            s.save()
+
+    await asyncio.gather(*[mutator(i) for i in range(50)])
+
+    loaded = PipelineState.load_or_new(output_dir=output, target_repo=tmp_path)
+    assert len(loaded.artifact_index) == 50
+    for i in range(50):
+        assert loaded.artifact_index[f"id-{i}"] == {"path": f"p{i}", "input_hash": f"h{i}"}
+
+
+def test_save_uses_atomic_write_no_tmp_leftover(tmp_path: Path) -> None:
+    output = tmp_path / "out"
+    output.mkdir()
+    s = PipelineState(target_repo=tmp_path, output_dir=output)
+    s.save()
+    siblings = [p.name for p in output.iterdir()]
+    assert ".designdoc-state.json" in siblings
+    assert not any(name.endswith(".tmp") for name in siblings)
+
+
+def test_save_json_is_valid_after_partial_tmp_left_behind(tmp_path: Path) -> None:
+    """If a stale .tmp exists from an earlier crash, save() should still succeed.
+
+    atomic_write's rename replaces the target; the leftover .tmp from a past
+    crash is overwritten on the next save's tempfile step."""
+    output = tmp_path / "out"
+    output.mkdir()
+    stale_tmp = output / ".designdoc-state.json.tmp"
+    stale_tmp.write_text("GARBAGE")
+
+    s = PipelineState(target_repo=tmp_path, output_dir=output)
+    s.save()
+
+    # Target is valid JSON.
+    data = json.loads((output / ".designdoc-state.json").read_text())
+    assert data["target_repo"] == str(tmp_path)
+    # .tmp cleanly replaced (no longer GARBAGE, or gone entirely).
+    if stale_tmp.exists():
+        # If still present, it must contain the JSON that was about to be renamed.
+        assert stale_tmp.read_text() != "GARBAGE"

--- a/uv.lock
+++ b/uv.lock
@@ -285,7 +285,7 @@ wheels = [
 
 [[package]]
 name = "designdoc"
-version = "1.1.0"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
## Summary

Within-stage crash-resume. A pipeline killed mid-Stage-N no longer loses that stage's partial progress — the rerun skips any artifact whose input hash still matches the checkpoint. Budget-cap halts are now graceful exits with a resume-message format.

### Added
- **Within-stage checkpointing.** Stages 2 (file summaries), 3 (class docs), 4 (package rollups), 5 (mermaid), and 6 (tech-debt topics) write to `state.artifact_index` after every completed artifact, under an `asyncio.Lock`. Mid-stage crash + rerun never re-calls the LLM for already-produced artifacts.
- **Atomic artifact writes.** New `designdoc.io_utils.atomic_write(path, content)` writes to a sibling `.tmp` then `os.replace()` (POSIX-atomic). Every artifact and `.designdoc-state.json` itself use it.
- **Graceful budget halt.** `BudgetExceededError` mid-stage now sets `state.halted_on_budget=True`, marks the stage FAILED, saves state. CLI prints `budget exhausted at $X / cap $Y. Run` `designdoc resume --budget <new-cap>` `to continue` with **exit 0** (was exit 4).
- **Observability.** Orchestrator stage-start log lines include the count of already-checkpointed artifacts (e.g. `[3/9] stage class_docs: 40 artifacts checkpointed`).

### Changed
- `PipelineState.artifact_index` is now `dict[str, dict[str, str]]` carrying `{"path": ..., "input_hash": ...}` per artifact. Old-shape state files are migrated in-memory with empty `input_hash` — safe fallback that forces reprocessing.
- `Orchestrator.run()` no longer re-raises `BudgetExceededError`. CLI reads `state.halted_on_budget` after the run and formats the resume message itself.

### Fixed
- Concurrent `state.save()` under `asyncio.gather` is now serialized by a module-level `asyncio.Lock`, preventing lost writes at `parallelism > 1`.

## Test plan

- [x] `task ci` — 95 tests passing (lint + format + unit + integration)
- [x] New unit + integration coverage:
  - [x] `tests/unit/test_io_utils.py` — atomic_write helper
  - [x] `tests/unit/test_state_backcompat.py` — v1.1 → v1.2 artifact_index migration
  - [x] `tests/integration/test_state_concurrent_save.py` — gather-children save lock
  - [x] `tests/integration/test_stage{2,3,4,5,6}_resume.py` — per-stage checkpoint resume
  - [x] `tests/integration/test_budget_halt.py` — graceful budget halt
  - [x] `tests/integration/test_orchestrator_checkpoint_logs.py` — log observability
  - [x] `tests/integration/test_within_stage_resume_e2e.py` — full-pipeline halt+resume with deterministic fake SDK
- [x] Byte-identical tree hash + exact resume-phase doer call count asserted in the e2e integration test (stronger than the plan's original live-API byte-compare, which LLM non-determinism would have broken)

## Plan deviations
- **Task 10**: Helper mapping uses real `dep:` prefix (plan had stale `topic:`); test seed keys use realistic `<path>::<Class>` form.
- **Task 11**: Replaced the plan's live-API subprocess test with an integration-level test using a deterministic fake SDK. The original byte-identical-against-live-API approach was doomed by LLM non-determinism; the fake-SDK version directly asserts checkpointed artifacts are reused (counts Stage-3 doer calls in the resume phase).

## Post-merge
After this PR is merged to `main`, tag `v1.2.0` on main and cut the GitHub release using the CHANGELOG v1.2.0 section as the notes body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
