### PR TITLE
chore: link follow-up plan to GitHub issues #6-#18

### DIFF
--- a/plans/2026_04_22_ultrareview_followup.md
+++ b/plans/2026_04_22_ultrareview_followup.md
@@ -24,29 +24,29 @@ Issue # column is back-filled in a separate PR after issue creation.
 
 | # | Issue | Title | Evidence | Suggested branch |
 |---|---|---|---|---|
-| 1 | _TBD_ | `fix: asyncio.gather lets sibling tasks burn budget after BudgetExceededError` | `s2_file_analysis.py:111`, `s3_class_docs.py:136`, `s6_tech_debt.py:126` | `fix/budget-leak-under-parallelism` |
-| 2 | _TBD_ | `fix: split total_retries metric into doer-content vs checker-parse retries` | `state.py:33`, `cli.py:223`; refs INV-001 action item | `fix/inv-001-total-retries-metric` |
-| 3 | _TBD_ | `fix: use atomic_write in s7_system_rollup, s0_discover, s1_index` | `s7_system_rollup.py:92-93`, `s0_discover.py:35`, `s1_index.py:43` | `fix/atomic-writes-stages-0-1-7` |
-| 4 | _TBD_ | `fix: add within-stage checkpoint to stage 7 (or document carve-out)` | `s7_system_rollup.py:55` (no `artifact_index`) | `fix/stage7-within-stage-resume` |
-| 5 | _TBD_ | `chore: enforce state_lock around all state.save() call sites` | `orchestrator.py:134`, `s0_discover.py:35`, `s1_index.py:26`, `s7_system_rollup.py:46`, `s8_finalize.py:28,42` | `chore/serialize-state-saves` |
+| 1 | [#6](https://github.com/SpillwaveSolutions/docgen/issues/6) | `fix: asyncio.gather lets sibling tasks burn budget after BudgetExceededError` | `s2_file_analysis.py:111`, `s3_class_docs.py:136`, `s6_tech_debt.py:126` | `fix/budget-leak-under-parallelism` |
+| 2 | [#7](https://github.com/SpillwaveSolutions/docgen/issues/7) | `fix: split total_retries metric into doer-content vs checker-parse retries` | `state.py:33`, `cli.py:223`; refs INV-001 action item | `fix/inv-001-total-retries-metric` |
+| 3 | [#8](https://github.com/SpillwaveSolutions/docgen/issues/8) | `fix: use atomic_write in s7_system_rollup, s0_discover, s1_index` | `s7_system_rollup.py:92-93`, `s0_discover.py:35`, `s1_index.py:43` | `fix/atomic-writes-stages-0-1-7` |
+| 4 | [#9](https://github.com/SpillwaveSolutions/docgen/issues/9) | `fix: add within-stage checkpoint to stage 7 (or document carve-out)` | `s7_system_rollup.py:55` (no `artifact_index`) | `fix/stage7-within-stage-resume` |
+| 5 | [#10](https://github.com/SpillwaveSolutions/docgen/issues/10) | `chore: enforce state_lock around all state.save() call sites` | `orchestrator.py:134`, `s0_discover.py:35`, `s1_index.py:26`, `s7_system_rollup.py:46`, `s8_finalize.py:28,42` | `chore/serialize-state-saves` |
 
 ### Tier 2 — High-value refactors (5 tickets, `enhancement` template)
 
 | # | Issue | Title | Evidence | Suggested branch |
 |---|---|---|---|---|
-| 6 | _TBD_ | `refactor: extract sha1_keyed helper from 4 stage hash duplications` | `s4:137`, `s7:109`, `s6:140`, `s6:153` | `refactor/io-utils-sha1-keyed` |
-| 7 | _TBD_ | `refactor: deduplicate _current_source_hashes between s2 and s3` | `s2:127` ↔ `s3:156` (literal copy-paste) | `refactor/dedupe-source-hashes` |
-| 8 | _TBD_ | `refactor: move per-stage kwargs and id-prefix into StageEntry` | `orchestrator.py:159` `_id_belongs_to_stage`, `:173` `_stage_kwargs` | `refactor/stage-entry-self-describing` |
-| 9 | _TBD_ | `refactor: extract _ship_with_hil shared by doer_checker_loop and doer_schema_loop` | `loop.py:98-115` ↔ `loop.py:264-268` | `refactor/loop-ship-with-hil-helper` |
-| 10 | _TBD_ | `refactor: route mermaid checker output through MermaidIssue (or delete the class)` | `verdict.py:35` defined; `mermaid/loop.py:60-69` emits plain `CheckerIssue` | `refactor/mermaid-issue-or-delete` |
+| 6 | [#11](https://github.com/SpillwaveSolutions/docgen/issues/11) | `refactor: extract sha1_keyed helper from 4 stage hash duplications` | `s4:137`, `s7:109`, `s6:140`, `s6:153` | `refactor/io-utils-sha1-keyed` |
+| 7 | [#12](https://github.com/SpillwaveSolutions/docgen/issues/12) | `refactor: deduplicate _current_source_hashes between s2 and s3` | `s2:127` ↔ `s3:156` (literal copy-paste) | `refactor/dedupe-source-hashes` |
+| 8 | [#13](https://github.com/SpillwaveSolutions/docgen/issues/13) | `refactor: move per-stage kwargs and id-prefix into StageEntry` | `orchestrator.py:159` `_id_belongs_to_stage`, `:173` `_stage_kwargs` | `refactor/stage-entry-self-describing` |
+| 9 | [#14](https://github.com/SpillwaveSolutions/docgen/issues/14) | `refactor: extract _ship_with_hil shared by doer_checker_loop and doer_schema_loop` | `loop.py:98-115` ↔ `loop.py:264-268` | `refactor/loop-ship-with-hil-helper` |
+| 10 | [#15](https://github.com/SpillwaveSolutions/docgen/issues/15) | `refactor: route mermaid checker output through MermaidIssue (or delete the class)` | `verdict.py:35` defined; `mermaid/loop.py:60-69` emits plain `CheckerIssue` | `refactor/mermaid-issue-or-delete` |
 
 ### Tier 3-5 — Batched cleanup (3 tickets, `enhancement` template, checklists)
 
 | # | Issue | Title | Sub-items |
 |---|---|---|---|
-| 11 | _TBD_ | `chore: polish pass — dead exports, naming, type hints` | T3.1 drop dead `noqa: F401` for `AgentDef` re-export (`loop.py:30`) · T3.2 rename `_SDKProtocol` → `SDKProtocol` (`runner.py:38`) · T3.3 add `RunnerProtocol(Protocol)` to replace `runner: Any` (`loop.py:26`) · T3.4 collapse dead `isinstance(e, ValidationError)` branch under `except Exception` (`cli.py:140-153`) · T3.5 promote `_CompositeCheckerRunner` to module-level dataclass (`mermaid/loop.py:78`) · T3.6 collapse default-duplication in `load_config` (`config.py:60-75`) |
-| 12 | _TBD_ | `test: add guard tests for invariants and fragile glue` | T4.1 type-level guard for invariant 2 (no self-grading) — assert checker prompt never contains prior-attempt content · T4.2 unit test for `_id_belongs_to_stage` classifier (`orchestrator.py:159`) · T4.3 assertion in `test_runner_mcp.py` that `setting_sources` + `mcp__<server>__*` glob get added when `mcp_servers` is non-empty (`runner.py:78-81`) · T4.4 add missing `test_stage8_resume.py` |
-| 13 | _TBD_ | `chore: silent-failure cleanup` | T5.1 narrow bare `except Exception:` in `_parse_or_placeholder` (`s2_file_analysis.py:154-164`) and log unexpecteds · T5.2 add path-traversal assertion in `_class_doc_path` (`s3_class_docs.py:176-183`) · T5.3 log `JSONDecodeError` in `_parse_report` (`s6_tech_debt.py:165-178`) · T5.4 use `atomic_write` in `hil.py:78` and `resolve.py:37` |
+| 11 | [#16](https://github.com/SpillwaveSolutions/docgen/issues/16) | `chore: polish pass — dead exports, naming, type hints` | T3.1 drop dead `noqa: F401` for `AgentDef` re-export (`loop.py:30`) · T3.2 rename `_SDKProtocol` → `SDKProtocol` (`runner.py:38`) · T3.3 add `RunnerProtocol(Protocol)` to replace `runner: Any` (`loop.py:26`) · T3.4 collapse dead `isinstance(e, ValidationError)` branch under `except Exception` (`cli.py:140-153`) · T3.5 promote `_CompositeCheckerRunner` to module-level dataclass (`mermaid/loop.py:78`) · T3.6 collapse default-duplication in `load_config` (`config.py:60-75`) |
+| 12 | [#17](https://github.com/SpillwaveSolutions/docgen/issues/17) | `test: add guard tests for invariants and fragile glue` | T4.1 type-level guard for invariant 2 (no self-grading) — assert checker prompt never contains prior-attempt content · T4.2 unit test for `_id_belongs_to_stage` classifier (`orchestrator.py:159`) · T4.3 assertion in `test_runner_mcp.py` that `setting_sources` + `mcp__<server>__*` glob get added when `mcp_servers` is non-empty (`runner.py:78-81`) · T4.4 add missing `test_stage8_resume.py` |
+| 13 | [#18](https://github.com/SpillwaveSolutions/docgen/issues/18) | `chore: silent-failure cleanup` | T5.1 narrow bare `except Exception:` in `_parse_or_placeholder` (`s2_file_analysis.py:154-164`) and log unexpecteds · T5.2 add path-traversal assertion in `_class_doc_path` (`s3_class_docs.py:176-183`) · T5.3 log `JSONDecodeError` in `_parse_report` (`s6_tech_debt.py:165-178`) · T5.4 use `atomic_write` in `hil.py:78` and `resolve.py:37` |
 
 ---
 
@@ -54,19 +54,19 @@ Issue # column is back-filled in a separate PR after issue creation.
 
 | Issue | Status | Closed by |
 |---|---|---|
-| #1 | open | — |
-| #2 | open | — |
-| #3 | open | — |
-| #4 | open | — |
-| #5 | open | — |
-| #6 | open | — |
-| #7 | open | — |
-| #8 | open | — |
-| #9 | open | — |
-| #10 | open | — |
-| #11 | open | — |
-| #12 | open | — |
-| #13 | open | — |
+| [#6](https://github.com/SpillwaveSolutions/docgen/issues/6)   | open | — |
+| [#7](https://github.com/SpillwaveSolutions/docgen/issues/7)   | open | — |
+| [#8](https://github.com/SpillwaveSolutions/docgen/issues/8)   | open | — |
+| [#9](https://github.com/SpillwaveSolutions/docgen/issues/9)   | open | — |
+| [#10](https://github.com/SpillwaveSolutions/docgen/issues/10) | open | — |
+| [#11](https://github.com/SpillwaveSolutions/docgen/issues/11) | open | — |
+| [#12](https://github.com/SpillwaveSolutions/docgen/issues/12) | open | — |
+| [#13](https://github.com/SpillwaveSolutions/docgen/issues/13) | open | — |
+| [#14](https://github.com/SpillwaveSolutions/docgen/issues/14) | open | — |
+| [#15](https://github.com/SpillwaveSolutions/docgen/issues/15) | open | — |
+| [#16](https://github.com/SpillwaveSolutions/docgen/issues/16) | open | — |
+| [#17](https://github.com/SpillwaveSolutions/docgen/issues/17) | open | — |
+| [#18](https://github.com/SpillwaveSolutions/docgen/issues/18) | open | — |
 
 When a PR lands and closes its issue, replace `open` with `closed` and fill
 in the PR number. When all 13 are closed, delete this file and the related


### PR DESCRIPTION
## Summary

Back-fills issue numbers (#6-#18) into the 13-row tracking table in `plans/2026_04_22_ultrareview_followup.md` so the plan and the GitHub work ledger stay in sync.

## Why

The plan was committed in PR #5 with `_TBD_` placeholders (issue creation comes after the plan exists). All 13 issues are now open; the plan needs to point at them.

## Changes

- `plans/2026_04_22_ultrareview_followup.md`: replace `_TBD_` with linked issue references in both the per-tier tables and the status-tracking table.

## Verification

- [x] All 13 issues exist and are open (`gh issue list --state open` returns matching titles).
- [x] Plan-row N maps to issue # in the table.

## Related

Builds on PR #5 (the plan itself). Does not close any issue — sets up tracking for issues #6-#18.