### PR TITLE
docs: add active-plan pointer in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,6 +95,9 @@ is a record of merged PRs, not in-progress work.
   closeable; "task ci green on test X" is.
 - **Labels** follow `.github/ISSUE_TEMPLATE/`: `bug`, `enhancement`, `investigation`.
 
+**Active follow-up work:** see `plans/2026_04_22_ultrareview_followup.md`
+(issues #6-#18, opened from the 2026-04-22 ULTRAREVIEW pass).
+
 ## Specs live under `./plans/`
 
 | Path | Contents |


### PR DESCRIPTION
## Summary

Adds a one-line "Active follow-up work" pointer under the "GitHub Issues = the work ledger" section of CONTRIBUTING.md, referencing `plans/2026_04_22_ultrareview_followup.md` and issues #6-#18.

## Why

The project's PR Workflow says "GitHub Issues are the canonical work ledger" — but a fresh contributor cloning the repo has no entry point to the in-flight ULTRAREVIEW work without scrolling through 13 individual issues. The pointer makes the active plan discoverable in one place.

CLAUDE.md and AGENT.md are gitignored per the project's per-developer agent-context convention, so the pointer was also added to those files locally but does not ship in this PR.

## Changes

- `CONTRIBUTING.md`: 3-line addition at end of "GitHub Issues = the work ledger" section.

## Verification

- [x] Pointer correctly references `plans/2026_04_22_ultrareview_followup.md`.
- [x] Issue range #6-#18 matches the 13 ULTRAREVIEW tickets created in PR #5 + back-filled in PR #19.

## Related

Builds on PR #5 (plan) and PR #19 (back-fill). When all 13 ULTRAREVIEW tickets close, this pointer should be removed in the same cleanup PR that deletes the plan file.