### PR TITLE
fix: use atomic_write in s7_system_rollup, s0_discover, s1_index

### DIFF
--- a/src/designdoc/stages/s0_discover.py
+++ b/src/designdoc/stages/s0_discover.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 
 from designdoc.index.discover import DiscoveryReport, discover
+from designdoc.io_utils import atomic_write
 from designdoc.state import PipelineState, StageStatus
 
 STAGE_NAME = "discover"
@@ -32,7 +33,10 @@ async def run(
     )
 
     state.output_dir.mkdir(parents=True, exist_ok=True)
-    (state.output_dir / OUTPUT_FILENAME).write_text(json.dumps(report.to_dict(), indent=2))
+    atomic_write(
+        state.output_dir / OUTPUT_FILENAME,
+        json.dumps(report.to_dict(), indent=2),
+    )
 
     state.stages[STAGE_NAME] = StageStatus.DONE
     state.current_stage = max(state.current_stage, 1)

--- a/src/designdoc/stages/s1_index.py
+++ b/src/designdoc/stages/s1_index.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 import json
 
 from designdoc.index.signatures import FileSignature, extract_signature
+from designdoc.io_utils import atomic_write
 from designdoc.stages.s0_discover import OUTPUT_FILENAME as STAGE0_FILENAME
 from designdoc.state import PipelineState, StageStatus
 
@@ -40,7 +41,7 @@ async def run(*, state: PipelineState) -> list[FileSignature]:
             continue
 
     out_path = state.output_dir / OUTPUT_FILENAME
-    out_path.write_text(json.dumps([s.to_dict() for s in signatures], indent=2))
+    atomic_write(out_path, json.dumps([s.to_dict() for s in signatures], indent=2))
 
     state.stages[STAGE_NAME] = StageStatus.DONE
     state.current_stage = max(state.current_stage, 2)

--- a/src/designdoc/stages/s7_system_rollup.py
+++ b/src/designdoc/stages/s7_system_rollup.py
@@ -17,6 +17,7 @@ from designdoc.agents.system_designer import (
     split_doer_output,
 )
 from designdoc.hil import inline_comment
+from designdoc.io_utils import atomic_write
 from designdoc.loop import doer_checker_loop
 from designdoc.state import PipelineState, StageStatus
 
@@ -89,8 +90,8 @@ async def run(
         sys_md = prefix + sys_md
         arch_md = prefix + arch_md
 
-    sys_path.write_text(sys_md)
-    arch_path.write_text(arch_md)
+    atomic_write(sys_path, sys_md)
+    atomic_write(arch_path, arch_md)
 
     state.rollup_hashes[ROLLUP_KEY] = input_hash
     state.stages[STAGE_NAME] = StageStatus.DONE


### PR DESCRIPTION
## Summary

Three stages used bare `write_text`, bypassing the project's `atomic_write` pattern. Aligns them with every other stage; eliminates partial-write corruption risk on SIGKILL mid-stage.

## Why

Discovered during the 2026-04-22 ULTRAREVIEW silent-failure pass. The project ships an `atomic_write` helper (`src/designdoc/io_utils.py`) that writes to a `.tmp` sibling then `os.replace`s — atomic on POSIX. Every stage uses it except these three sites. A SIGKILL between writes leaves either truncated JSON (s0/s1) or an inconsistent doc pair (s7 SYSTEM_DESIGN.md + ARCHITECTURE.md), which the next resume can't recover from cleanly.

## Changes

- `src/designdoc/stages/s0_discover.py` — wrap `stage0_discovery.json` write with `atomic_write`.
- `src/designdoc/stages/s1_index.py` — wrap `stage1_signatures.json` write with `atomic_write`.
- `src/designdoc/stages/s7_system_rollup.py` — wrap both `SYSTEM_DESIGN.md` and `ARCHITECTURE.md` writes with `atomic_write`.
- Each file gains `from designdoc.io_utils import atomic_write` (alphabetically placed to match existing import style).

## Invariants

No invariants touched — pure I/O hygiene change. Behavior on the happy path is unchanged.

## Verification

- [x] `task ci` green locally — 95 passed in 63.87s
- [x] No new tests required per the issue's closing criteria (existing resume tests cover crash-during-stage)
- [x] TWRC discipline followed

## Related

Closes #8.