### PR TITLE
chore: polish pass — dead exports, naming, type hints

### DIFF
--- a/src/designdoc/cli.py
+++ b/src/designdoc/cli.py
@@ -16,6 +16,7 @@ from typing import Annotated
 
 import anyio
 import typer
+from pydantic import ValidationError
 
 from designdoc.budget import BUDGET_FILENAME, CostAccumulator
 from designdoc.config import load_config
@@ -136,21 +137,17 @@ def generate(
         raise typer.Exit(code=2)
 
     # Validate config surface early so bad diagram_format etc fail fast
-    # rather than at the first stage that would care.
+    # rather than at the first stage that would care. ValidationError is a
+    # ValueError subclass but caught explicitly first so the message stays
+    # clear if the broader ValueError clause ever needs to diverge.
     try:
         load_config(config)
+    except ValidationError as e:
+        typer.echo(f"invalid config: {e}", err=True)
+        raise typer.Exit(code=2) from e
     except (ValueError, TypeError) as e:
         typer.echo(f"invalid config: {e}", err=True)
         raise typer.Exit(code=2) from e
-    except Exception as e:
-        # Pydantic ValidationError is a ValueError subclass but surfaces as
-        # its own type; catch and map to exit 2 here.
-        from pydantic import ValidationError
-
-        if isinstance(e, ValidationError):
-            typer.echo(f"invalid config: {e}", err=True)
-            raise typer.Exit(code=2) from e
-        raise
 
     try:
         anyio.run(_run_orchestrator, repo_p, output, budget, skip_set, config, parallelism)

--- a/src/designdoc/config.py
+++ b/src/designdoc/config.py
@@ -43,7 +43,12 @@ class Config(BaseModel):
 
 
 def load_config(path: Path | None) -> Config:
-    """Load config from TOML. Returns defaults if path is None."""
+    """Load config from TOML. Returns defaults if path is None.
+
+    Defaults live exclusively on the ``Config`` model. We forward only the keys
+    the user actually supplied so pydantic fills the rest — no risk of the
+    ``.get(key, default)`` and the model declaration drifting apart.
+    """
     if path is None:
         return Config()
     if not path.exists():
@@ -57,19 +62,24 @@ def load_config(path: Path | None) -> Config:
     out = raw.get("output", {})
     models = raw.get("models", {})
 
-    return Config(
-        max_budget_usd=pipe.get("max_budget_usd", 5.00),
-        parallelism=pipe.get("parallelism", 3),
-        resume=pipe.get("resume", True),
-        skip_stages=stages.get("skip", []),
-        only_stages=stages.get("only", []),
-        include_languages=langs.get("include", Config().include_languages),
-        exclude_paths=langs.get("exclude_paths", Config().exclude_paths),
-        perplexity_mcp=mcp.get("perplexity", True),
-        context7_mcp=mcp.get("context7", True),
-        agent_brain_mcp=mcp.get("agent_brain", False),
-        output_dir=out.get("dir", "docs/design"),
-        diagram_format=out.get("diagram_format", "mermaid"),
-        doer_model=models.get("doer", "claude-sonnet-4-6"),
-        checker_model=models.get("checker", "claude-sonnet-4-6"),
-    )
+    # Map each TOML key onto its Config field name, skipping anything the
+    # user didn't set. Anything not present here falls back to the model
+    # default automatically.
+    candidate_fields: dict[str, object] = {
+        "max_budget_usd": pipe.get("max_budget_usd"),
+        "parallelism": pipe.get("parallelism"),
+        "resume": pipe.get("resume"),
+        "skip_stages": stages.get("skip"),
+        "only_stages": stages.get("only"),
+        "include_languages": langs.get("include"),
+        "exclude_paths": langs.get("exclude_paths"),
+        "perplexity_mcp": mcp.get("perplexity"),
+        "context7_mcp": mcp.get("context7"),
+        "agent_brain_mcp": mcp.get("agent_brain"),
+        "output_dir": out.get("dir"),
+        "diagram_format": out.get("diagram_format"),
+        "doer_model": models.get("doer"),
+        "checker_model": models.get("checker"),
+    }
+    overrides = {k: v for k, v in candidate_fields.items() if v is not None}
+    return Config(**overrides)

--- a/src/designdoc/loop.py
+++ b/src/designdoc/loop.py
@@ -23,11 +23,11 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Literal
+from typing import Literal
 
 from pydantic import BaseModel, ValidationError
 
-from designdoc.runner import AgentDef  # noqa: F401 — re-export for callers
+from designdoc.runner import AgentDef, RunnerProtocol
 from designdoc.verdict import (
     SYNTH_FAIL_PREFIX,
     CheckerIssue,
@@ -70,7 +70,7 @@ async def doer_checker_loop(
     checker: AgentDef,
     doer_prompt: str,
     checker_prompt_fn: Callable[[str], str],
-    runner: Any,
+    runner: RunnerProtocol,
     hil_sink: list[dict],
     stage_name: str = "unknown",
     debug_dir: Path | None = None,
@@ -217,7 +217,7 @@ async def doer_schema_loop(
     doer: AgentDef,
     doer_prompt: str,
     schema_model: type[BaseModel],
-    runner: Any,
+    runner: RunnerProtocol,
     hil_sink: list[dict],
     stage_name: str = "unknown",
 ) -> ArtifactResult:

--- a/src/designdoc/mermaid/loop.py
+++ b/src/designdoc/mermaid/loop.py
@@ -10,7 +10,8 @@ from __future__ import annotations
 
 import json
 import re
-from typing import Any
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 
 from designdoc.agents.mermaid_generator import (
     build_doer_prompt,
@@ -20,7 +21,7 @@ from designdoc.agents.mermaid_generator import (
 )
 from designdoc.loop import ArtifactResult, doer_checker_loop
 from designdoc.mermaid.mmdc import validate as mmdc_validate
-from designdoc.runner import AgentDef
+from designdoc.runner import AgentDef, RunnerProtocol, RunResult
 
 FENCE_RE = re.compile(r"^```(?:mermaid)?\s*\n?|\n?```\s*$", re.MULTILINE)
 
@@ -30,11 +31,32 @@ def strip_fence(text: str) -> str:
     return FENCE_RE.sub("", text).strip()
 
 
+@dataclass
+class _CompositeCheckerRunner:
+    """Proxy runner that routes the synthetic ``mermaid-combined-checker`` agent
+    through ``combined_check`` (mmdc syntax + LLM semantic). All other agents
+    pass through to ``inner`` unchanged.
+
+    Conforms to ``RunnerProtocol``: the loop only ever calls ``run(agent, prompt)``.
+    Promoted to module level (rather than nested inside the factory) so it can
+    be unit-tested in isolation.
+    """
+
+    inner: RunnerProtocol
+    combined_check: Callable[[str], Awaitable[str]]
+
+    async def run(self, agent: AgentDef, prompt: str) -> RunResult:
+        if agent.name == "mermaid-combined-checker":
+            text = await self.combined_check(prompt)
+            return RunResult(text=text, input_tokens=0, output_tokens=0, cost_usd=0.0)
+        return await self.inner.run(agent, prompt)
+
+
 async def generate_validated_mermaid(
     *,
     artifact_name: str,
     artifact_text: str,
-    runner: Any,
+    runner: RunnerProtocol,
     hil_sink: list[dict],
     doer: AgentDef | None = None,
     validator: AgentDef | None = None,
@@ -75,20 +97,6 @@ async def generate_validated_mermaid(
         semantic_result = await runner.run(validator, semantic_prompt)
         return semantic_result.text
 
-    class _CompositeCheckerRunner:
-        """Proxy runner that routes checker calls through combined_check."""
-
-        def __init__(self, inner):
-            self.inner = inner
-
-        async def run(self, agent, prompt):
-            if agent.name == "mermaid-combined-checker":
-                text = await combined_check(prompt)
-                from designdoc.runner import RunResult
-
-                return RunResult(text=text, input_tokens=0, output_tokens=0, cost_usd=0.0)
-            return await self.inner.run(agent, prompt)
-
     # The combined checker is synthetic — it routes through combined_check.
     # The loop sees one "checker" AgentDef; our proxy intercepts and runs both.
     composite_checker = AgentDef(
@@ -107,7 +115,7 @@ async def generate_validated_mermaid(
         checker=composite_checker,
         doer_prompt=build_doer_prompt(artifact_name, artifact_text),
         checker_prompt_fn=checker_prompt_fn,
-        runner=_CompositeCheckerRunner(runner),
+        runner=_CompositeCheckerRunner(inner=runner, combined_check=combined_check),
         hil_sink=hil_sink,
         stage_name=stage_name,
     )

--- a/src/designdoc/runner.py
+++ b/src/designdoc/runner.py
@@ -35,12 +35,23 @@ class RunResult:
     cost_usd: float
 
 
-class _SDKProtocol(Protocol):
+class SDKProtocol(Protocol):
     async def query(self, *, prompt: str, options: dict) -> dict: ...
 
 
+class RunnerProtocol(Protocol):
+    """Public surface every doer/checker loop expects from a runner.
+
+    `ClaudeSDKRunner` implements this; tests inject fakes that conform.
+    Loop modules type-hint against this Protocol rather than `Any` so the
+    runner contract is checkable.
+    """
+
+    async def run(self, agent: AgentDef, prompt: str) -> RunResult: ...
+
+
 class ClaudeSDKRunner:
-    def __init__(self, budget: CostAccumulator, sdk: _SDKProtocol | None = None):
+    def __init__(self, budget: CostAccumulator, sdk: SDKProtocol | None = None):
         self.budget = budget
         self.sdk = sdk if sdk is not None else _DefaultSDK()
 


### PR DESCRIPTION
## Summary

Six mechanical polish items from the 2026-04-22 ULTRAREVIEW Tier 3 list, bundled in one PR per the issue's design.

## Why

Small inconsistencies and stale annotations across the codebase that don't individually warrant a ticket but collectively reduce friction. No behavior change.

## Changes

- **T3.1** `loop.py:30` — drop misleading `# noqa: F401 — re-export for callers` comment. (`AgentDef` is actually used as a type annotation locally — the noqa was wrong on two counts. Import kept; comment removed.)
- **T3.2** `runner.py:38` — rename `_SDKProtocol` → `SDKProtocol` (public injection point; leading underscore was misleading).
- **T3.3** `runner.py` — add `RunnerProtocol(Protocol)` declaring `async def run(agent, prompt) -> RunResult`. Replace `runner: Any` in `loop.py` (both `doer_checker_loop` and `doer_schema_loop`) and `mermaid/loop.py:generate_validated_mermaid` with the new protocol. Remove now-unused `Any` imports.
- **T3.4** `cli.py` — hoist `from pydantic import ValidationError`; collapse the try/except so `except ValidationError` is its own clause and the dead inner `isinstance(e, ValidationError)` branch under `except Exception` is removed.
- **T3.5** `mermaid/loop.py` — promote `_CompositeCheckerRunner` to a module-level `@dataclass` with `inner: RunnerProtocol` and `combined_check` fields. Now unit-testable in isolation.
- **T3.6** `config.py` — replace doubled-default pattern with a `candidate_fields` dict + `Config(**overrides)`. Defaults now live exclusively on the `Config` model declaration.

## Invariants

- [x] MAX_ATTEMPTS=3 preserved (loop.py)
- [x] Checker isolation preserved (no self-grading)
- [x] Schema-validated verdicts / fail-loud preserved
- [x] Mermaid two-checker (mmdc + LLM) preserved
- [x] HIL fallback preserved

`test_config_does_not_expose_max_attempts` constitutional guard still passes.

## Verification

- [x] `task ci` green locally — 151 unit + 95 integration tests passed
- [x] No new tests required (mechanical polish)
- [x] TWRC discipline followed

## Related

Closes #16.