### PR TITLE
chore: enforce state_lock around all state.save() call sites

### DIFF
--- a/src/designdoc/orchestrator.py
+++ b/src/designdoc/orchestrator.py
@@ -32,7 +32,7 @@ from designdoc.stages import (
     s7_system_rollup,
     s8_finalize,
 )
-from designdoc.state import PipelineState, StageStatus
+from designdoc.state import PipelineState, StageStatus, state_lock
 
 log = logging.getLogger(__name__)
 
@@ -131,7 +131,8 @@ class Orchestrator:
             except BudgetExceededError:
                 self.state.stages[entry.name] = StageStatus.FAILED
                 self.state.halted_on_budget = True
-                self.state.save()
+                async with state_lock:
+                    self.state.save()
                 self.budget.save()
                 log.info(
                     "[%d/%d] stage %s halted after %.1fs (budget exceeded) — "

--- a/src/designdoc/stages/s0_discover.py
+++ b/src/designdoc/stages/s0_discover.py
@@ -10,7 +10,7 @@ import json
 
 from designdoc.index.discover import DiscoveryReport, discover
 from designdoc.io_utils import atomic_write
-from designdoc.state import PipelineState, StageStatus
+from designdoc.state import PipelineState, StageStatus, state_lock
 
 STAGE_NAME = "discover"
 OUTPUT_FILENAME = "stage0_discovery.json"
@@ -24,7 +24,8 @@ async def run(
 ) -> DiscoveryReport:
     """Execute Stage 0 and checkpoint the result."""
     state.stages[STAGE_NAME] = StageStatus.RUNNING
-    state.save()
+    async with state_lock:
+        state.save()
 
     report = discover(
         state.target_repo,
@@ -40,5 +41,6 @@ async def run(
 
     state.stages[STAGE_NAME] = StageStatus.DONE
     state.current_stage = max(state.current_stage, 1)
-    state.save()
+    async with state_lock:
+        state.save()
     return report

--- a/src/designdoc/stages/s1_index.py
+++ b/src/designdoc/stages/s1_index.py
@@ -11,7 +11,7 @@ import json
 from designdoc.index.signatures import FileSignature, extract_signature
 from designdoc.io_utils import atomic_write
 from designdoc.stages.s0_discover import OUTPUT_FILENAME as STAGE0_FILENAME
-from designdoc.state import PipelineState, StageStatus
+from designdoc.state import PipelineState, StageStatus, state_lock
 
 STAGE_NAME = "index"
 OUTPUT_FILENAME = "stage1_signatures.json"
@@ -24,7 +24,8 @@ async def run(*, state: PipelineState) -> list[FileSignature]:
         raise FileNotFoundError(f"stage 0 output missing ({stage0_path}); run stage 0 first")
 
     state.stages[STAGE_NAME] = StageStatus.RUNNING
-    state.save()
+    async with state_lock:
+        state.save()
 
     data = json.loads(stage0_path.read_text())
     repo_root = state.target_repo
@@ -45,5 +46,6 @@ async def run(*, state: PipelineState) -> list[FileSignature]:
 
     state.stages[STAGE_NAME] = StageStatus.DONE
     state.current_stage = max(state.current_stage, 2)
-    state.save()
+    async with state_lock:
+        state.save()
     return signatures

--- a/src/designdoc/stages/s7_system_rollup.py
+++ b/src/designdoc/stages/s7_system_rollup.py
@@ -19,7 +19,7 @@ from designdoc.agents.system_designer import (
 from designdoc.hil import inline_comment
 from designdoc.io_utils import atomic_write
 from designdoc.loop import doer_checker_loop
-from designdoc.state import PipelineState, StageStatus
+from designdoc.state import PipelineState, StageStatus, state_lock
 
 STAGE_NAME = "system_rollup"
 SYSTEM_FILENAME = "SYSTEM_DESIGN.md"
@@ -44,7 +44,8 @@ async def run(
         raise FileNotFoundError("no package READMEs found — run Stage 4 first")
 
     state.stages[STAGE_NAME] = StageStatus.RUNNING
-    state.save()
+    async with state_lock:
+        state.save()
 
     sys_path = state.output_dir / SYSTEM_FILENAME
     arch_path = state.output_dir / ARCHITECTURE_FILENAME
@@ -59,7 +60,8 @@ async def run(
     ):
         state.stages[STAGE_NAME] = StageStatus.DONE
         state.current_stage = max(state.current_stage, 8)
-        state.save()
+        async with state_lock:
+            state.save()
         return {
             SYSTEM_FILENAME: str(sys_path.relative_to(state.output_dir)),
             ARCHITECTURE_FILENAME: str(arch_path.relative_to(state.output_dir)),
@@ -96,7 +98,8 @@ async def run(
     state.rollup_hashes[ROLLUP_KEY] = input_hash
     state.stages[STAGE_NAME] = StageStatus.DONE
     state.current_stage = max(state.current_stage, 8)
-    state.save()
+    async with state_lock:
+        state.save()
     return {
         SYSTEM_FILENAME: str(sys_path.relative_to(state.output_dir)),
         ARCHITECTURE_FILENAME: str(arch_path.relative_to(state.output_dir)),

--- a/src/designdoc/stages/s8_finalize.py
+++ b/src/designdoc/stages/s8_finalize.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 from designdoc.hil import HILIssue, append_issue
 from designdoc.stages.s0_discover import OUTPUT_FILENAME as STAGE0_FILENAME
-from designdoc.state import PipelineState, StageStatus
+from designdoc.state import PipelineState, StageStatus, state_lock
 
 STAGE_NAME = "finalize"
 README_FILENAME = "README.md"
@@ -25,7 +25,8 @@ async def run(*, state: PipelineState) -> dict[str, str]:
     output.mkdir(parents=True, exist_ok=True)
 
     state.stages[STAGE_NAME] = StageStatus.RUNNING
-    state.save()
+    async with state_lock:
+        state.save()
 
     readme_path = output / README_FILENAME
     readme_path.write_text(_render_toc(output))
@@ -41,7 +42,8 @@ async def run(*, state: PipelineState) -> dict[str, str]:
 
     state.stages[STAGE_NAME] = StageStatus.DONE
     state.current_stage = max(state.current_stage, 9)
-    state.save()
+    async with state_lock:
+        state.save()
     return {
         "readme": str(readme_path.relative_to(output)),
         "hil": str(hil_path.relative_to(output)) if hil_path.exists() else "",


### PR DESCRIPTION
## Summary

Wraps every previously-unlocked `state.save()` call site in `async with state_lock:`, matching the pattern stages 2-6 already use. Eliminates a latent concurrency footgun.

## Why

Discovered during the 2026-04-22 ULTRAREVIEW architecture pass. `state_lock` is a module-level `asyncio.Lock` (`state.py`); stages 2-6 acquire it before `state.save()`, but stages 0/1/7/8 and the orchestrator itself called `state.save()` outside the lock. Currently safe (no concurrent writer crosses stage boundaries) but the invariant "saves are locked" wasn't actually true — and it would break under any future stage that gathers across stage boundaries.

## Changes

All 9 sites converted to `async with state_lock: state.save()` — uniform pattern, no comment-justified skips:

| File | Sites |
|---|---|
| `orchestrator.py` | line 134 (BudgetExceededError handler in `Orchestrator.run`) |
| `s0_discover.py` | RUNNING + DONE checkpoints |
| `s1_index.py` | RUNNING + DONE checkpoints |
| `s7_system_rollup.py` | RUNNING + skip-when-cached DONE + final DONE |
| `s8_finalize.py` | RUNNING + DONE checkpoints |

Each affected file imports `state_lock` via the existing `from designdoc.state import ...` line.

## Invariants

No invariants touched — concurrency hygiene only. Behavior unchanged in single-stage runs.

- [x] MAX_ATTEMPTS=3 preserved (loop.py untouched)
- [x] Checker isolation preserved
- [x] Schema-validated verdicts preserved
- [x] Mermaid two-checker preserved
- [x] HIL fallback preserved

## Verification

- [x] `task ci` green locally — 95 tests passed in 67.76s
- [x] No new tests required per the issue's closing criteria; existing 95-test suite passes unchanged (confirms no test relied on `state.save()` running outside an event loop)
- [x] TWRC discipline followed
- [x] Branched from post-#8 main; no conflict expected with the now-merged atomic_write changes (different lines in the same files)

## Related

Closes #10.