### PR TITLE
refactor: extract _ship_with_hil shared by both retry loops

### DIFF
--- a/src/designdoc/loop.py
+++ b/src/designdoc/loop.py
@@ -96,22 +96,13 @@ async def doer_checker_loop(
             return ArtifactResult(artifact_id, "pass", current_text, attempt, verdict)
 
         if attempt == MAX_ATTEMPTS:
-            hil_sink.append(
-                _build_hil_entry(
-                    artifact_id,
-                    stage_name,
-                    current_text,
-                    verdict,
-                    attempt,
-                    hil_sink,
-                )
-            )
-            return ArtifactResult(
-                artifact_id,
-                "shipped_with_hil",
-                current_text,
-                attempt,
-                verdict,
+            return _ship_with_hil(
+                artifact_id=artifact_id,
+                stage_name=stage_name,
+                current_text=current_text,
+                verdict=verdict,
+                attempt=attempt,
+                hil_sink=hil_sink,
             )
 
         # Retry with ONLY this attempt's issues — no cumulative drift.
@@ -119,6 +110,32 @@ async def doer_checker_loop(
         current_text = (await runner.run(doer, retry_prompt)).text
 
     raise AssertionError("unreachable")  # pragma: no cover
+
+
+def _ship_with_hil(
+    *,
+    artifact_id: str,
+    stage_name: str,
+    current_text: str,
+    verdict: CheckerVerdict,
+    attempt: int,
+    hil_sink: list[dict],
+) -> ArtifactResult:
+    """Append HIL entry and return shipped_with_hil ArtifactResult.
+
+    Shared by doer_checker_loop and doer_schema_loop — the MAX_ATTEMPTS
+    branch is identical in both and must stay identical (Invariant 5).
+    """
+    hil_sink.append(
+        _build_hil_entry(artifact_id, stage_name, current_text, verdict, attempt, hil_sink)
+    )
+    return ArtifactResult(
+        artifact_id,
+        "shipped_with_hil",
+        current_text,
+        attempt,
+        verdict,
+    )
 
 
 def _build_retry_prompt(original: str, previous_output: str, verdict: CheckerVerdict) -> str:
@@ -262,10 +279,14 @@ async def doer_schema_loop(
             )
 
         if attempt == MAX_ATTEMPTS:
-            hil_sink.append(
-                _build_hil_entry(artifact_id, stage_name, current_text, verdict, attempt, hil_sink)
+            return _ship_with_hil(
+                artifact_id=artifact_id,
+                stage_name=stage_name,
+                current_text=current_text,
+                verdict=verdict,
+                attempt=attempt,
+                hil_sink=hil_sink,
             )
-            return ArtifactResult(artifact_id, "shipped_with_hil", current_text, attempt, verdict)
 
         retry_prompt = _build_retry_prompt(doer_prompt, current_text, verdict)
         current_text = (await runner.run(doer, retry_prompt)).text


### PR DESCRIPTION
## Summary

Extracts `_ship_with_hil(...)` helper shared by `doer_checker_loop` and `doer_schema_loop` so any future change to Invariant 5 (HIL fallback) lands in one place.

## Why

Discovered during the 2026-04-22 ULTRAREVIEW invariant audit. `loop.py:98-115` (in `doer_checker_loop`) and `loop.py:264-268` (in `doer_schema_loop`) implemented the MAX_ATTEMPTS HIL-fallback branch verbatim. Any future change — e.g., enriching the HIL entry with extra metadata — would need to land in two places. Exactly the "loosen one without the other" failure mode that invariants are meant to prevent.

## Changes

- `src/designdoc/loop.py`: +40 / -19
  - New private `_ship_with_hil(*, artifact_id, stage_name, current_text, verdict, attempt, hil_sink) -> ArtifactResult` at module level, between `doer_checker_loop` and `_build_retry_prompt`.
  - Both MAX_ATTEMPTS branches collapse to `return _ship_with_hil(...)` keyword-argument calls.

## Invariants preserved (critical — this file is load-bearing)

- [x] **Invariant 1** (Python enforces control flow) — each loop still has the visible inline `if attempt == MAX_ATTEMPTS: return _ship_with_hil(...)` guard. The cap check was NOT moved out of the loop; only the duplicated body after the check was consolidated.
- [x] **Invariant 5** (HIL fallback after 3 failures) — HIL entry generation via `_build_hil_entry` is unchanged; the helper wraps the `hil_sink.append(...) + return ArtifactResult(...)` sequence that was duplicated.
- [x] MAX_ATTEMPTS=3 preserved (unchanged constant).
- [x] Checker isolation preserved.
- [x] Schema-validated verdicts preserved.
- [x] Mermaid two-checker preserved.

## Verification

- [x] `task ci` green locally — 95 tests passed in 66.64s
- [x] `tests/unit/test_loop.py` passes unmodified — including:
  - `test_ships_with_hil_after_3_fails` (the 6-call assertion confirms MAX_ATTEMPTS behavior unchanged)
  - `test_malformed_checker_output_counts_as_attempt`
- [x] `tests/unit/test_file_analyzer.py::test_schema_loop_hil_after_3_fails` passes, confirming `doer_schema_loop` HIL path still works with the shared helper
- [x] TWRC discipline followed

## Related

Closes #14.