### PR TITLE
refactor: extract sha1_keyed helper from 4 stage hash duplications

### DIFF
--- a/src/designdoc/io_utils.py
+++ b/src/designdoc/io_utils.py
@@ -3,10 +3,16 @@
 atomic_write writes to a sibling .tmp file then os.replace(): on POSIX this
 is atomic. A SIGKILL between the two steps leaves either a partial .tmp
 (ignored on next run) or a complete target — never a truncated target.
+
+sha1_keyed is a shared digest helper used by stages that checkpoint on input
+hashes (s4 package rollups, s6 tech-debt, s7 system rollup). It must produce
+byte-identical output to the prior per-stage `_hash_*` helpers so existing
+`.designdoc-state.json` artifact_index entries remain valid across upgrades.
 """
 
 from __future__ import annotations
 
+import hashlib
 import os
 from pathlib import Path
 
@@ -15,3 +21,27 @@ def atomic_write(path: Path, content: str) -> None:
     tmp = path.with_suffix(path.suffix + ".tmp")
     tmp.write_text(content)
     os.replace(tmp, path)
+
+
+def sha1_keyed(items: dict[str, str]) -> str:
+    """SHA1 hex digest of a dict, keyed by sorted keys.
+
+    For each key in ``sorted(items)`` the digest absorbs::
+
+        key_utf8 + b"\\0" + value_utf8 + b"\\n"
+
+    This encoding is the shared shape of the pre-refactor ``_hash_class_docs``
+    (s4), ``_hash_readmes`` (s7), and ``_hash_deps`` / ``_hash_dep`` (s6)
+    helpers. For s6, the triple ``(name, pinned, source)`` is flattened into a
+    single dict entry whose value is ``f"{pinned}\\0{source}"`` so the absorbed
+    bytes remain ``name\\0pinned\\0source\\n`` — byte-identical to the legacy
+    implementation. Stability across Python runs and platforms is required;
+    used for resume / incremental bookkeeping in state.json.
+    """
+    h = hashlib.sha1()
+    for key in sorted(items):
+        h.update(key.encode("utf-8"))
+        h.update(b"\0")
+        h.update(items[key].encode("utf-8"))
+        h.update(b"\n")
+    return h.hexdigest()

--- a/src/designdoc/stages/s4_package_rollups.py
+++ b/src/designdoc/stages/s4_package_rollups.py
@@ -13,7 +13,6 @@ made. On any change, regenerate and update the recorded hash.
 from __future__ import annotations
 
 import asyncio
-import hashlib
 from pathlib import Path
 
 from designdoc.agents.package_documenter import (
@@ -23,7 +22,7 @@ from designdoc.agents.package_documenter import (
     make_package_documenter,
 )
 from designdoc.hil import inline_comment
-from designdoc.io_utils import atomic_write
+from designdoc.io_utils import atomic_write, sha1_keyed
 from designdoc.loop import doer_checker_loop
 from designdoc.state import PipelineState, StageStatus, state_lock
 
@@ -57,7 +56,7 @@ async def run(
             continue
         pkg_name = pkg_dir.name
         rollup_key = f"package:{pkg_name}"
-        input_hash = _hash_class_docs(class_docs)
+        input_hash = sha1_keyed(class_docs)
         readme_path = pkg_dir / "README.md"
 
         if state.rollup_hashes.get(rollup_key) == input_hash and readme_path.exists():
@@ -132,14 +131,3 @@ def _collect_class_docs(pkg_dir: Path) -> dict[str, str]:
         for p in sorted(classes_dir.glob("*.md"))
         if not p.name.startswith(".")
     }
-
-
-def _hash_class_docs(class_docs: dict[str, str]) -> str:
-    """Stable SHA1 over class docs keyed by filename (sorted)."""
-    h = hashlib.sha1()
-    for name in sorted(class_docs):
-        h.update(name.encode("utf-8"))
-        h.update(b"\0")
-        h.update(class_docs[name].encode("utf-8"))
-        h.update(b"\n")
-    return h.hexdigest()

--- a/src/designdoc/stages/s6_tech_debt.py
+++ b/src/designdoc/stages/s6_tech_debt.py
@@ -17,7 +17,6 @@ mid-stage crash leaves a consistent (partial) ledger on disk.
 from __future__ import annotations
 
 import asyncio
-import hashlib
 import json
 
 from designdoc.agents.tech_debt import (
@@ -27,13 +26,24 @@ from designdoc.agents.tech_debt import (
     make_tech_debt_researcher,
 )
 from designdoc.index.manifests import Dep, parse_manifests
-from designdoc.io_utils import atomic_write
+from designdoc.io_utils import atomic_write, sha1_keyed
 from designdoc.loop import doer_checker_loop
 from designdoc.state import PipelineState, StageStatus, state_lock
 
 STAGE_NAME = "tech_debt"
 OUTPUT_FILENAME = "TECH_DEBT.md"
 ROLLUP_KEY = "tech_debt"
+
+
+def _dep_hash_items(deps: list[Dep]) -> dict[str, str]:
+    """Encode deps as a dict keyed by name whose value packs ``pinned\\0source``.
+
+    When fed into :func:`designdoc.io_utils.sha1_keyed`, the resulting digest
+    absorbs ``name\\0pinned\\0source\\n`` for each dep in sorted(name) order —
+    byte-identical to the pre-refactor ``_hash_deps`` / ``_hash_dep`` helpers,
+    so existing state.json/artifact_index entries remain valid.
+    """
+    return {dep.name: f"{dep.pinned}\0{dep.source}" for dep in deps}
 
 
 async def run(
@@ -50,7 +60,7 @@ async def run(
     state.save()
 
     deps = parse_manifests(state.target_repo)
-    input_hash = _hash_deps(deps)
+    input_hash = sha1_keyed(_dep_hash_items(deps))
     output_path = state.output_dir / OUTPUT_FILENAME
 
     # v1.1 cross-run skip: whole-stage skip when dep manifest is unchanged.
@@ -71,7 +81,7 @@ async def run(
     # to exist — if TECH_DEBT.md was deleted the checkpoint is stale.
     rows: dict[str, dict] = {}
     for dep in deps:
-        dep_input_hash = _hash_dep(dep)
+        dep_input_hash = sha1_keyed(_dep_hash_items([dep]))
         artifact_id = f"dep:{dep.name}"
         prior = state.artifact_index.get(artifact_id, {})
         if (
@@ -91,7 +101,7 @@ async def run(
     to_process = [dep for dep in deps if dep.name not in rows]
 
     async def _one(dep: Dep) -> None:
-        dep_input_hash = _hash_dep(dep)
+        dep_input_hash = sha1_keyed(_dep_hash_items([dep]))
         async with sem:
             doer_prompt = build_researcher_prompt(dep.name, dep.pinned)
 
@@ -135,31 +145,6 @@ async def run(
         state.current_stage = max(state.current_stage, 7)
         state.save()
     return final_rows
-
-
-def _hash_deps(deps: list[Dep]) -> str:
-    """Stable SHA1 over (name, pinned, source) sorted by name."""
-    h = hashlib.sha1()
-    for dep in sorted(deps, key=lambda d: d.name):
-        h.update(dep.name.encode("utf-8"))
-        h.update(b"\0")
-        h.update(dep.pinned.encode("utf-8"))
-        h.update(b"\0")
-        h.update(dep.source.encode("utf-8"))
-        h.update(b"\n")
-    return h.hexdigest()
-
-
-def _hash_dep(dep: Dep) -> str:
-    """SHA1 of a single dep's (name, pinned, source) triple."""
-    h = hashlib.sha1()
-    h.update(dep.name.encode("utf-8"))
-    h.update(b"\0")
-    h.update(dep.pinned.encode("utf-8"))
-    h.update(b"\0")
-    h.update(dep.source.encode("utf-8"))
-    h.update(b"\n")
-    return h.hexdigest()
 
 
 def _parse_report(text: str, dep, disputed: bool) -> dict:

--- a/src/designdoc/stages/s7_system_rollup.py
+++ b/src/designdoc/stages/s7_system_rollup.py
@@ -7,8 +7,6 @@ existing SYSTEM_DESIGN.md + ARCHITECTURE.md and skip the LLM call.
 
 from __future__ import annotations
 
-import hashlib
-
 from designdoc.agents.system_designer import (
     build_checker_prompt,
     build_doer_prompt,
@@ -17,7 +15,7 @@ from designdoc.agents.system_designer import (
     split_doer_output,
 )
 from designdoc.hil import inline_comment
-from designdoc.io_utils import atomic_write
+from designdoc.io_utils import atomic_write, sha1_keyed
 from designdoc.loop import doer_checker_loop
 from designdoc.state import PipelineState, StageStatus, state_lock
 
@@ -49,7 +47,7 @@ async def run(
 
     sys_path = state.output_dir / SYSTEM_FILENAME
     arch_path = state.output_dir / ARCHITECTURE_FILENAME
-    input_hash = _hash_readmes(pkg_readmes)
+    input_hash = sha1_keyed(pkg_readmes)
 
     # Skip when inputs match the last successful regeneration AND both
     # outputs still exist (guard against manual deletes).
@@ -108,14 +106,3 @@ async def run(
 
 def _collect_readmes(packages_dir) -> dict[str, str]:
     return {p.parent.name: p.read_text() for p in sorted(packages_dir.glob("*/README.md"))}
-
-
-def _hash_readmes(readmes: dict[str, str]) -> str:
-    """Stable SHA1 over package READMEs keyed by package name (sorted)."""
-    h = hashlib.sha1()
-    for name in sorted(readmes):
-        h.update(name.encode("utf-8"))
-        h.update(b"\0")
-        h.update(readmes[name].encode("utf-8"))
-        h.update(b"\n")
-    return h.hexdigest()

--- a/tests/integration/test_stage6_resume.py
+++ b/tests/integration/test_stage6_resume.py
@@ -15,8 +15,9 @@ from pathlib import Path
 import pytest
 
 from designdoc.budget import CostAccumulator
+from designdoc.io_utils import sha1_keyed
 from designdoc.runner import ClaudeSDKRunner
-from designdoc.stages.s6_tech_debt import _hash_dep
+from designdoc.stages.s6_tech_debt import _dep_hash_items
 from designdoc.stages.s6_tech_debt import run as stage_tech_debt
 from designdoc.state import PipelineState
 
@@ -138,7 +139,7 @@ async def test_stage6_partial_crash_resume(tmp_path: Path) -> None:
     # Simulate 'requests' having been completed before crash:
     # manually compute its input_hash and plant it in artifact_index with a row.
     requests_dep = Dep(name="requests", pinned=">=2.31", source="pyproject.toml")
-    req_hash = _hash_dep(requests_dep)
+    req_hash = sha1_keyed(_dep_hash_items([requests_dep]))
     req_row = {
         "name": "requests",
         "pinned": ">=2.31",

--- a/tests/unit/test_io_utils.py
+++ b/tests/unit/test_io_utils.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import hashlib
 from pathlib import Path
 
 import pytest
 
-from designdoc.io_utils import atomic_write
+from designdoc.io_utils import atomic_write, sha1_keyed
 
 
 def test_atomic_write_creates_target(tmp_path: Path) -> None:
@@ -42,3 +43,84 @@ def test_atomic_write_tmp_is_gone_after_replace(tmp_path: Path) -> None:
     tmp = target.with_suffix(target.suffix + ".tmp")
     assert not tmp.exists()
     assert target.exists()
+
+
+# ---------------------------------------------------------------------------
+# sha1_keyed: stable SHA1 over dict items sorted by key.
+# ---------------------------------------------------------------------------
+
+
+def _legacy_hash(items: dict[str, str]) -> str:
+    """Reference implementation matching the pre-refactor _hash_* helpers.
+
+    Used to lock in byte-identical hashes so existing state.json/artifact_index
+    entries are not invalidated by the refactor.
+    """
+    h = hashlib.sha1()
+    for key in sorted(items):
+        h.update(key.encode("utf-8"))
+        h.update(b"\0")
+        h.update(items[key].encode("utf-8"))
+        h.update(b"\n")
+    return h.hexdigest()
+
+
+def test_sha1_keyed_is_deterministic() -> None:
+    items = {"foo.md": "hello", "bar.md": "world"}
+    assert sha1_keyed(items) == sha1_keyed(items)
+
+
+def test_sha1_keyed_is_order_independent() -> None:
+    a = {"a": "1", "b": "2"}
+    b = {"b": "2", "a": "1"}
+    assert sha1_keyed(a) == sha1_keyed(b)
+
+
+def test_sha1_keyed_is_content_sensitive() -> None:
+    base = {"a": "1", "b": "2"}
+    changed_value = {"a": "1", "b": "3"}
+    changed_key = {"a": "1", "c": "2"}
+    assert sha1_keyed(base) != sha1_keyed(changed_value)
+    assert sha1_keyed(base) != sha1_keyed(changed_key)
+
+
+def test_sha1_keyed_empty_dict_is_empty_sha1() -> None:
+    # Empty input hashes to the SHA1 of the empty string, matching the
+    # pre-refactor helpers (the for-loop simply never runs).
+    assert sha1_keyed({}) == hashlib.sha1().hexdigest()
+
+
+def test_sha1_keyed_matches_legacy_single_pair() -> None:
+    """Guards against the refactor accidentally changing hash bytes for the
+    single-key case the way _hash_class_docs / _hash_readmes used it."""
+    items = {"only.md": "content"}
+    assert sha1_keyed(items) == _legacy_hash(items)
+
+
+def test_sha1_keyed_matches_legacy_multi_pair() -> None:
+    items = {
+        "alpha": "one",
+        "beta": "two",
+        "gamma": "three with\nnewlines and \0 nulls",
+    }
+    assert sha1_keyed(items) == _legacy_hash(items)
+
+
+def test_sha1_keyed_matches_legacy_dep_triple_encoding() -> None:
+    """_hash_dep / _hash_deps emitted name\\0pinned\\0source\\n per row.
+
+    The refactor encodes each row as a dict entry whose value is
+    f"{pinned}\\0{source}"; this test locks in byte-identical output.
+    """
+    # Legacy s6 per-dep encoding, inlined.
+    legacy = hashlib.sha1()
+    legacy.update(b"requests")
+    legacy.update(b"\0")
+    legacy.update(b">=2.31")
+    legacy.update(b"\0")
+    legacy.update(b"pyproject.toml")
+    legacy.update(b"\n")
+    expected = legacy.hexdigest()
+
+    via_sha1_keyed = sha1_keyed({"requests": ">=2.31\0pyproject.toml"})
+    assert via_sha1_keyed == expected


### PR DESCRIPTION
## Summary

Consolidates 4 `_hash_*` functions across s4/s6/s7 into a single `io_utils.sha1_keyed(items: dict[str, str])` helper. Hash values are **byte-identical** to the prior implementations — no `state.json` invalidation.

## Why

Discovered during the 2026-04-22 ULTRAREVIEW code-quality pass. Four functions (`_hash_class_docs` in s4, `_hash_readmes` in s7, `_hash_deps` + `_hash_dep` in s6) implemented the same SHA1-of-sorted-dict pattern. Any future change to the hashing scheme would need to land in four places — exactly the "loosen one without the other" failure mode.

## Byte-identity protection

Three dedicated unit tests lock in byte-identical behavior against a legacy reference implementation:
- `test_sha1_keyed_matches_legacy_single_pair` — single-key case
- `test_sha1_keyed_matches_legacy_multi_pair` — multi-key case with nulls/newlines in values
- `test_sha1_keyed_matches_legacy_dep_triple_encoding` — captures s6's three-field `name\0pinned\0source\n` encoding

Plus end-to-end proof: all existing resume/incremental integration tests for s4/s6/s7 pass against state.json from prior runs.

## Changes

- **NEW** `io_utils.sha1_keyed(items: dict[str, str]) -> str`
- **NEW** 7 unit tests in `tests/unit/test_io_utils.py` (determinism, order-independence, content-sensitivity, 3 legacy byte-identity tests, one edge case)
- **Deleted**: `_hash_class_docs` (s4), `_hash_readmes` (s7), `_hash_deps` (s6), `_hash_dep` (s6) — four private helpers, all single/low-call-site, direct replacement.
- **Kept**: `_dep_hash_items(deps)` in s6 — a 1-line stage-local adapter that packs `list[Dep]` into `{name: f"{pinned}\0{source}"}`. Used from 3 call sites (whole-stage hash + two per-dep checkpoints) and documents the encoding invariant. Kept as a named helper for clarity.
- Updated `tests/integration/test_stage6_resume.py` — import updated to use `_dep_hash_items` + `sha1_keyed`.

## Invariants

No invariants touched — pure extraction. Behavior unchanged; hash values byte-identical.

- [x] MAX_ATTEMPTS=3 preserved
- [x] Checker isolation preserved
- [x] Schema-validated verdicts preserved
- [x] Mermaid two-checker preserved
- [x] HIL fallback preserved

## Verification

- [x] `task ci` green — 158 unit + 95 integration tests passed
- [x] 3 byte-identity tests against legacy reference lock in hash stability
- [x] Existing state-resume tests pass (end-to-end proof no state.json is invalidated)
- [x] TWRC discipline followed

## Related

Closes #11.