### PR TITLE
fix: split total_retries into doer_content_retries + checker_parse_retries

### DIFF
--- a/plans/future_improvements_investigations.md
+++ b/plans/future_improvements_investigations.md
@@ -97,7 +97,7 @@ Both reviewers independently endorse the raw-output capture as the decisive next
 - [x] Extend `parse_verdict` with a defensive code-fence-strip pass. Done 2026-04-21.
 - [x] Add unit test fixtures of real-world malformed checker outputs. Done — `tests/unit/test_verdict.py` gained 6 fence-behavior tests.
 - [ ] Run a full end-to-end dogfood to confirm 0 HILs post-fix (replay on captures already proved 9/9 false failures now parse as pass).
-- [ ] Distinguish "checker parse retries" from "doer content retries" in `total_retries` stat.
+- [x] Distinguish "checker parse retries" from "doer content retries" in `total_retries` stat. Done 2026-04-23 — split into `doer_content_retries` + `checker_parse_retries` (PR #7).
 - [ ] Consider migrating high-value checker paths to Anthropic's tool-use JSON mode (Codex's preferred long-term fix; not required to resolve INV-001).
 
 ### Diagnostic findings (2026-04-21)

--- a/src/designdoc/cli.py
+++ b/src/designdoc/cli.py
@@ -217,7 +217,11 @@ def status(
     for name, status_val in state.stages.items():
         typer.echo(f"  {name}: {status_val}")
     typer.echo(f"hil_issues: {len(state.hil_issues)}")
-    typer.echo(f"total_retries: {state.total_retries}")
+    # INV-001: split retry metric so readers can tell a checker-parse-flakiness
+    # problem (model emits unparseable JSON) from a doer-content-quality
+    # problem (doer can't hit the reviewer's bar).
+    typer.echo(f"doer_content_retries: {state.doer_content_retries}")
+    typer.echo(f"checker_parse_retries: {state.checker_parse_retries}")
 
     # Incremental-regeneration readiness hints.
     _print_incremental_hints(state)

--- a/src/designdoc/loop.py
+++ b/src/designdoc/loop.py
@@ -23,7 +23,7 @@ import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel, ValidationError
 
@@ -34,6 +34,9 @@ from designdoc.verdict import (
     CheckerVerdict,
     parse_verdict,
 )
+
+if TYPE_CHECKING:
+    from designdoc.state import PipelineState
 
 MAX_ATTEMPTS: int = 3
 """CANONICAL. Enforced here, nowhere else. Do not expose in config."""
@@ -74,11 +77,17 @@ async def doer_checker_loop(
     hil_sink: list[dict],
     stage_name: str = "unknown",
     debug_dir: Path | None = None,
+    state: PipelineState | None = None,
 ) -> ArtifactResult:
     """Run the doer/checker bouncer. Ships with HIL after MAX_ATTEMPTS failures.
 
     When debug_dir is set, every checker invocation's raw output + parse status
     is persisted under debug_dir. Opt-in diagnostic for INV-001.
+
+    When state is provided, the retry counters on it are incremented on the
+    retry branch (NOT on the terminal MAX_ATTEMPTS branch — that's ship-with-HIL,
+    not a retry). The increment site distinguishes checker-parse failures
+    (synthetic-fail verdict) from genuine doer-content objections.
     """
     effective_debug_dir = _resolve_debug_dir(debug_dir)
     current_text = (await runner.run(doer, doer_prompt)).text
@@ -105,11 +114,28 @@ async def doer_checker_loop(
                 hil_sink=hil_sink,
             )
 
+        _bump_retry_counter(state, verdict)
         # Retry with ONLY this attempt's issues — no cumulative drift.
         retry_prompt = _build_retry_prompt(doer_prompt, current_text, verdict)
         current_text = (await runner.run(doer, retry_prompt)).text
 
     raise AssertionError("unreachable")  # pragma: no cover
+
+
+def _bump_retry_counter(state: PipelineState | None, verdict: CheckerVerdict) -> None:
+    """Classify a failing verdict and increment the matching retry counter.
+
+    Called ONLY on the retry branch — the terminal MAX_ATTEMPTS ship-with-HIL
+    path deliberately does not count (it's a HIL event, not a retry). Split
+    intent: INV-001 action item — readers of `designdoc status` need to tell
+    "checker parse flakiness" apart from "doer couldn't hit quality bar."
+    """
+    if state is None:
+        return
+    if verdict.summary.startswith(SYNTH_FAIL_PREFIX):
+        state.checker_parse_retries += 1
+    else:
+        state.doer_content_retries += 1
 
 
 def _ship_with_hil(
@@ -237,12 +263,16 @@ async def doer_schema_loop(
     runner: RunnerProtocol,
     hil_sink: list[dict],
     stage_name: str = "unknown",
+    state: PipelineState | None = None,
 ) -> ArtifactResult:
     """Like doer_checker_loop but the checker is a pydantic schema.
 
     Use when the doer's output is strictly-structured and a parser suffices —
     saves the cost of a second LLM call. The retry prompt includes the exact
     pydantic ValidationError so the doer can self-correct the JSON shape.
+
+    Schema retries always count as doer_content_retries: the doer, not a
+    checker LLM, produced wrong-shape output and is being asked to revise.
     """
     current_text = (await runner.run(doer, doer_prompt)).text
 
@@ -288,6 +318,8 @@ async def doer_schema_loop(
                 hil_sink=hil_sink,
             )
 
+        if state is not None:
+            state.doer_content_retries += 1
         retry_prompt = _build_retry_prompt(doer_prompt, current_text, verdict)
         current_text = (await runner.run(doer, retry_prompt)).text
 

--- a/src/designdoc/state.py
+++ b/src/designdoc/state.py
@@ -30,7 +30,13 @@ class PipelineState:
     output_dir: Path
     current_stage: int = 0
     stages: dict[str, StageStatus] = field(default_factory=dict)
-    total_retries: int = 0
+    # Split (was total_retries pre-INV-001 split). Counts retries only — the
+    # terminal MAX_ATTEMPTS attempt that ships with HIL is NOT counted as a
+    # retry. See loop.py for the increment sites.
+    doer_content_retries: int = 0
+    """Retries triggered by genuine checker objections → doer revises content."""
+    checker_parse_retries: int = 0
+    """Retries triggered by synthetic-fail verdicts (checker output unparseable)."""
     hil_issues: list[dict] = field(default_factory=list)
     # v1.2: each artifact_index entry carries the output path AND the SHA1
     # of its inputs. On resume, an artifact is skipped only if the current
@@ -76,12 +82,20 @@ class PipelineState:
         path = output_dir / STATE_FILENAME
         if path.exists():
             d = json.loads(path.read_text())
+            # Backcompat: old state.json had total_retries; new split is
+            # doer_content_retries + checker_parse_retries. If new fields are
+            # absent, read old total_retries into doer_content_retries (the
+            # dominant case pre-split). If new fields exist, they win — an
+            # orphan legacy total_retries is ignored, not double-counted.
+            doer_content_retries = d.get("doer_content_retries", d.get("total_retries", 0))
+            checker_parse_retries = d.get("checker_parse_retries", 0)
             return cls(
                 target_repo=Path(d["target_repo"]),
                 output_dir=Path(d["output_dir"]),
                 current_stage=d["current_stage"],
                 stages={k: StageStatus(v) for k, v in d["stages"].items()},
-                total_retries=d["total_retries"],
+                doer_content_retries=doer_content_retries,
+                checker_parse_retries=checker_parse_retries,
                 hil_issues=d["hil_issues"],
                 artifact_index=_migrate_artifact_index(d.get("artifact_index", {})),
                 prev_hashes=d.get("prev_hashes", {}),

--- a/tests/unit/test_loop.py
+++ b/tests/unit/test_loop.py
@@ -10,11 +10,13 @@ reliability claim collapses. Specifically:
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 
 from designdoc.loop import doer_checker_loop
 from designdoc.runner import AgentDef, RunResult
+from designdoc.state import PipelineState
 
 
 class ScriptedRunner:
@@ -361,3 +363,128 @@ async def test_retry_prompt_contains_only_latest_issues():
     assert agent_name == "doer"
     assert "FIX-FROM-ATTEMPT-1" in retry_prompt  # latest issue
     assert "ORIGINAL-TASK" in retry_prompt  # original task included
+
+
+def _make_state(tmp_path: Path) -> PipelineState:
+    return PipelineState(target_repo=Path("/x"), output_dir=tmp_path)
+
+
+@pytest.mark.anyio
+async def test_parse_failure_retries_bump_checker_parse_counter(tmp_path):
+    """Three parse-failures → ships with HIL after 2 retries. Both retries
+    are checker-parse retries (synthetic-fail verdict). The terminal attempt
+    is NOT counted — it routes through _ship_with_hil, not the retry branch."""
+    runner = ScriptedRunner(
+        {
+            "doer": ["d1", "d2", "d3"],
+            "checker": ["not json", "also not json", "still not json"],
+        }
+    )
+    doer = AgentDef(name="doer", system_prompt="", model="m")
+    checker = AgentDef(name="checker", system_prompt="", model="m")
+    state = _make_state(tmp_path)
+
+    result = await doer_checker_loop(
+        artifact_id="x",
+        doer=doer,
+        checker=checker,
+        doer_prompt="p",
+        checker_prompt_fn=lambda d: d,
+        runner=runner,
+        hil_sink=state.hil_issues,
+        state=state,
+    )
+
+    assert result.status == "shipped_with_hil"
+    assert state.checker_parse_retries == 2
+    assert state.doer_content_retries == 0
+
+
+@pytest.mark.anyio
+async def test_content_failure_retries_bump_doer_content_counter(tmp_path):
+    """Three real-fail verdicts → ships with HIL after 2 retries. Both retries
+    are doer-content retries (genuine checker objections). Terminal not counted."""
+    runner = ScriptedRunner(
+        {
+            "doer": ["d1", "d2", "d3"],
+            "checker": [_fail_json(1), _fail_json(2), _fail_json(3)],
+        }
+    )
+    doer = AgentDef(name="doer", system_prompt="", model="m")
+    checker = AgentDef(name="checker", system_prompt="", model="m")
+    state = _make_state(tmp_path)
+
+    result = await doer_checker_loop(
+        artifact_id="x",
+        doer=doer,
+        checker=checker,
+        doer_prompt="p",
+        checker_prompt_fn=lambda d: d,
+        runner=runner,
+        hil_sink=state.hil_issues,
+        state=state,
+    )
+
+    assert result.status == "shipped_with_hil"
+    assert state.doer_content_retries == 2
+    assert state.checker_parse_retries == 0
+
+
+@pytest.mark.anyio
+async def test_mixed_failures_bump_both_counters_then_pass(tmp_path):
+    """Parse-fail → real-fail → pass. Two retries total, one of each kind.
+    Final pass does NOT increment either counter — the counters record
+    retries, not attempts."""
+    runner = ScriptedRunner(
+        {
+            "doer": ["d1", "d2", "d3"],
+            "checker": [
+                "not json",  # synthetic-fail → checker_parse_retries
+                _fail_json(2),  # real fail → doer_content_retries
+                '{"status":"pass","summary":"ok"}',  # pass
+            ],
+        }
+    )
+    doer = AgentDef(name="doer", system_prompt="", model="m")
+    checker = AgentDef(name="checker", system_prompt="", model="m")
+    state = _make_state(tmp_path)
+
+    result = await doer_checker_loop(
+        artifact_id="x",
+        doer=doer,
+        checker=checker,
+        doer_prompt="p",
+        checker_prompt_fn=lambda d: d,
+        runner=runner,
+        hil_sink=state.hil_issues,
+        state=state,
+    )
+
+    assert result.status == "pass"
+    assert state.checker_parse_retries == 1
+    assert state.doer_content_retries == 1
+
+
+@pytest.mark.anyio
+async def test_state_param_optional_preserves_backward_compat(tmp_path):
+    """Omitting state= must not crash — it's a kw-only default-None param so
+    in-tree tests that predate the split still work unchanged."""
+    runner = ScriptedRunner(
+        {
+            "doer": ["d1", "d2"],
+            "checker": ["not json", '{"status":"pass","summary":"ok"}'],
+        }
+    )
+    doer = AgentDef(name="doer", system_prompt="", model="m")
+    checker = AgentDef(name="checker", system_prompt="", model="m")
+
+    result = await doer_checker_loop(
+        artifact_id="x",
+        doer=doer,
+        checker=checker,
+        doer_prompt="p",
+        checker_prompt_fn=lambda d: d,
+        runner=runner,
+        hil_sink=[],
+    )
+    assert result.status == "pass"

--- a/tests/unit/test_state.py
+++ b/tests/unit/test_state.py
@@ -24,7 +24,8 @@ def test_roundtrip_preserves_all_fields(tmp_path: Path):
     s.stages["discover"] = StageStatus.DONE
     s.stages["index"] = StageStatus.RUNNING
     s.current_stage = 1
-    s.total_retries = 4
+    s.doer_content_retries = 3
+    s.checker_parse_retries = 1
     s.hil_issues.append({"id": "HIL-001", "severity": "major"})
     s.artifact_index["pkg.ClassA"] = {
         "path": "packages/pkg/classes/ClassA.md",
@@ -36,7 +37,8 @@ def test_roundtrip_preserves_all_fields(tmp_path: Path):
     assert s2.stages["discover"] == StageStatus.DONE
     assert s2.stages["index"] == StageStatus.RUNNING
     assert s2.current_stage == 1
-    assert s2.total_retries == 4
+    assert s2.doer_content_retries == 3
+    assert s2.checker_parse_retries == 1
     assert s2.hil_issues == [{"id": "HIL-001", "severity": "major"}]
     assert s2.artifact_index == {
         "pkg.ClassA": {

--- a/tests/unit/test_state_backcompat.py
+++ b/tests/unit/test_state_backcompat.py
@@ -70,3 +70,54 @@ def test_backcompat_migrated_values_force_reprocess(tmp_path: Path) -> None:
     # Pretend the current hash of the input is some real SHA.
     current_input_hash = "a" * 40
     assert entry["input_hash"] != current_input_hash
+
+
+def test_backcompat_total_retries_maps_to_doer_content_retries(tmp_path: Path) -> None:
+    """Old state.json had total_retries; new split is doer_content_retries +
+    checker_parse_retries. Since pre-split runs only ever incremented on the
+    doer-content path (that was the dominant case), the old value reads into
+    doer_content_retries and checker_parse_retries defaults to 0."""
+    output = tmp_path / "out"
+    output.mkdir()
+    old_state = {
+        "target_repo": str(tmp_path),
+        "output_dir": str(output),
+        "current_stage": 3,
+        "stages": {"class_docs": "done"},
+        "total_retries": 5,
+        "hil_issues": [],
+        "artifact_index": {},
+        "prev_hashes": {},
+        "rollup_hashes": {},
+    }
+    (output / STATE_FILENAME).write_text(json.dumps(old_state))
+
+    loaded = PipelineState.load_or_new(output_dir=output, target_repo=tmp_path)
+    assert loaded.doer_content_retries == 5
+    assert loaded.checker_parse_retries == 0
+
+
+def test_backcompat_new_fields_win_over_legacy_total_retries(tmp_path: Path) -> None:
+    """If a state file has both the new fields and legacy total_retries (e.g.
+    a mid-migration artifact), the new fields take precedence — legacy value
+    is ignored, not double-counted."""
+    output = tmp_path / "out"
+    output.mkdir()
+    mixed_state = {
+        "target_repo": str(tmp_path),
+        "output_dir": str(output),
+        "current_stage": 3,
+        "stages": {"class_docs": "done"},
+        "total_retries": 99,
+        "doer_content_retries": 3,
+        "checker_parse_retries": 2,
+        "hil_issues": [],
+        "artifact_index": {},
+        "prev_hashes": {},
+        "rollup_hashes": {},
+    }
+    (output / STATE_FILENAME).write_text(json.dumps(mixed_state))
+
+    loaded = PipelineState.load_or_new(output_dir=output, target_repo=tmp_path)
+    assert loaded.doer_content_retries == 3
+    assert loaded.checker_parse_retries == 2


### PR DESCRIPTION
## Summary

Splits the misleading `total_retries` metric into two distinct counters so `designdoc status` accurately reports retry activity. The old field was declared, persisted, and displayed — but never incremented anywhere, silently reporting `0` even when the pipeline burned all `MAX_ATTEMPTS` on multiple artifacts.

Closes #7. Refs INV-001 (`plans/future_improvements_investigations.md:100`).

## Why

INV-001 action item: readers of `designdoc status` currently can't distinguish
- a checker-parse-flakiness problem (model emits unparseable JSON → synthetic fail), from
- a doer-content-quality problem (doer can't hit the reviewer's bar → genuine objection).

Both burn retry budget, but only the second means anything about *content* correctness. A single counter conflates them; a metric that reads `0` when 8 artifacts × 3 attempts = 24 executions just happened is worse than useless.

## Changes

- `src/designdoc/state.py`: removed `total_retries`; added `doer_content_retries` and `checker_parse_retries`. `from_dict` migrates old `total_retries` values into `doer_content_retries` (the dominant pre-split case). Mixed state (new + legacy fields) lets the new fields win.
- `src/designdoc/loop.py`: `doer_checker_loop` and `doer_schema_loop` now accept an optional `state: PipelineState` kw-only param. On the retry branch (NOT terminal `MAX_ATTEMPTS` → `_ship_with_hil`), `_bump_retry_counter` classifies the verdict by `summary.startswith(SYNTH_FAIL_PREFIX)` and increments the matching counter.
- `src/designdoc/cli.py` `status` command: prints both counters on separate lines.
- `plans/future_improvements_investigations.md`: INV-001 action item marked done.
- Tests: updated `test_state.py`/`test_state_backcompat.py` for the new schema; added 4 loop tests covering parse-only, content-only, mixed, and back-compat-no-state paths; 2 new backcompat tests for the old-shape migration.

Stage callers (`s2`..`s7`) are unchanged — wiring `state=state` through call sites belongs to other parallel streams (#6, #9). The loop param defaults to `None`, so behavior is identical until a caller opts in.

## Invariants checklist

- [x] MAX_ATTEMPTS = 3 unchanged (constitutional constant in `loop.py`).
- [x] `test_config_does_not_expose_max_attempts` still passes (no config surface touched).
- [x] HIL fallback at MAX_ATTEMPTS unchanged — counter increment is deliberately skipped on the terminal branch.
- [x] No prompt-based control flow introduced.
- [x] No self-grading / checker isolation preserved — retry counter is a side channel, not input to the checker.

## Verification

- `task ci` local: 95 passed in 64.56s (lint + ruff format + unit + integration).
- New tests directly prove: 3 parse-fails → `checker_parse_retries == 2`, 3 real-fails → `doer_content_retries == 2`, parse→real→pass → 1 of each.
- Back-compat: old state.json files with `total_retries: 5` load as `doer_content_retries=5, checker_parse_retries=0`.

## Test plan

- [x] `task ci` green locally.
- [ ] Reviewer confirms stage-caller wiring (stages/s2..s7) intentionally deferred to #6 / #9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)