### PR TITLE
fix: wire state=state into all stage doer_checker_loop callers

### DIFF
--- a/src/designdoc/mermaid/loop.py
+++ b/src/designdoc/mermaid/loop.py
@@ -22,6 +22,7 @@ from designdoc.agents.mermaid_generator import (
 from designdoc.loop import ArtifactResult, doer_checker_loop
 from designdoc.mermaid.mmdc import validate as mmdc_validate
 from designdoc.runner import AgentDef, RunnerProtocol, RunResult
+from designdoc.state import PipelineState
 
 FENCE_RE = re.compile(r"^```(?:mermaid)?\s*\n?|\n?```\s*$", re.MULTILINE)
 
@@ -61,6 +62,7 @@ async def generate_validated_mermaid(
     doer: AgentDef | None = None,
     validator: AgentDef | None = None,
     stage_name: str = "mermaid",
+    state: PipelineState | None = None,
 ) -> ArtifactResult:
     """Generate a mermaid diagram for `artifact_text` and validate it.
 
@@ -117,5 +119,6 @@ async def generate_validated_mermaid(
         checker_prompt_fn=checker_prompt_fn,
         runner=_CompositeCheckerRunner(inner=runner, combined_check=combined_check),
         hil_sink=hil_sink,
+        state=state,
         stage_name=stage_name,
     )

--- a/src/designdoc/stages/s2_file_analysis.py
+++ b/src/designdoc/stages/s2_file_analysis.py
@@ -93,6 +93,7 @@ async def run(
                 runner=runner,
                 hil_sink=state.hil_issues,
                 stage_name=STAGE_NAME,
+                state=state,
             )
             summary = _parse_or_placeholder(result.text, path)
 

--- a/src/designdoc/stages/s3_class_docs.py
+++ b/src/designdoc/stages/s3_class_docs.py
@@ -115,6 +115,7 @@ async def run(
                 runner=runner,
                 hil_sink=state.hil_issues,
                 stage_name=STAGE_NAME,
+                state=state,
             )
             content = result.text
             if result.status == "shipped_with_hil":

--- a/src/designdoc/stages/s4_package_rollups.py
+++ b/src/designdoc/stages/s4_package_rollups.py
@@ -92,6 +92,7 @@ async def run(
                 runner=runner,
                 hil_sink=state.hil_issues,
                 stage_name=STAGE_NAME,
+                state=state,
             )
             content = result.text
             if result.status == "shipped_with_hil":

--- a/src/designdoc/stages/s5_mermaid.py
+++ b/src/designdoc/stages/s5_mermaid.py
@@ -76,6 +76,7 @@ async def run(
             runner=runner,
             hil_sink=state.hil_issues,
             stage_name=STAGE_NAME,
+            state=state,
         )
 
         mermaid_src = strip_fence(result.text)

--- a/src/designdoc/stages/s6_tech_debt.py
+++ b/src/designdoc/stages/s6_tech_debt.py
@@ -118,6 +118,7 @@ async def run(
                 runner=runner,
                 hil_sink=state.hil_issues,
                 stage_name=STAGE_NAME,
+                state=state,
             )
             row = _parse_report(result.text, dep, disputed=result.status != "pass")
 

--- a/src/designdoc/stages/s7_system_rollup.py
+++ b/src/designdoc/stages/s7_system_rollup.py
@@ -88,6 +88,7 @@ async def run(
         runner=runner,
         hil_sink=state.hil_issues,
         stage_name=STAGE_NAME,
+        state=state,
     )
 
     sys_md, arch_md = split_doer_output(result.text)


### PR DESCRIPTION
## Summary

Follow-up to #7. Wires `state=state` into every `doer_checker_loop` / `doer_schema_loop` / `generate_validated_mermaid` caller so the new retry counters actually increment.

## Why

PR #30 introduced `doer_content_retries` + `checker_parse_retries` as an optional kwarg on the loop functions (`state: PipelineState | None = None`). Stage callers were deliberately NOT edited in that PR because they belonged to #6's parallel stream at the time. The agent on #7 flagged this gap explicitly:

> Per the task's "do not touch" list, stage callers (s2..s7) were NOT edited — the loop's state param defaults to None so those stages won't tick counters until #6/#9 wires them. Flagged explicitly in the PR body.

With #6 and #9 now merged, this PR closes that gap. Without it, the counters remain 0 in practice even though the schema + increment logic is in place.

## Changes

6 call sites, 1 line per site plus one signature extension:

- `stages/s2_file_analysis.py` — `doer_schema_loop(..., state=state)`
- `stages/s3_class_docs.py` — `doer_checker_loop(..., state=state)`
- `stages/s4_package_rollups.py` — `doer_checker_loop(..., state=state)`
- `stages/s6_tech_debt.py` — `doer_checker_loop(..., state=state)`
- `stages/s7_system_rollup.py` — `doer_checker_loop(..., state=state)`
- `mermaid/loop.py` — add `state: PipelineState | None = None` to `generate_validated_mermaid` signature; thread through to `doer_checker_loop`. `stages/s5_mermaid.py` passes `state=state` to the wrapper.

## Invariants

- [x] MAX_ATTEMPTS=3 preserved
- [x] Checker isolation preserved (state is a side channel for metrics only — never reaches the checker)
- [x] Schema-validated verdicts preserved
- [x] Mermaid two-checker preserved
- [x] HIL fallback preserved

## Verification

- [x] `task ci` green — 100 integration tests passed (up from 95, since earlier PRs added 4 stage-7 resume tests + 1 budget-parallel test)
- [x] No behavior change for callers not passing state (still None-safe per #7's design)

## Related

Part of #7. Not closing a ticket (the wiring gap was implicit in #7's closing criteria but was split to a follow-up because of parallel-batch file ownership).