### PR TITLE
chore: mark issues #6, #7, #9 closed in follow-up plan

### DIFF
--- a/plans/2026_04_22_ultrareview_followup.md
+++ b/plans/2026_04_22_ultrareview_followup.md
@@ -54,10 +54,10 @@ Issue # column is back-filled in a separate PR after issue creation.
 
 | Issue | Status | Closed by |
 |---|---|---|
-| [#6](https://github.com/SpillwaveSolutions/docgen/issues/6)   | open   | — |
-| [#7](https://github.com/SpillwaveSolutions/docgen/issues/7)   | open   | — |
+| [#6](https://github.com/SpillwaveSolutions/docgen/issues/6)   | closed | [PR #31](https://github.com/SpillwaveSolutions/docgen/pull/31) |
+| [#7](https://github.com/SpillwaveSolutions/docgen/issues/7)   | closed | [PR #30](https://github.com/SpillwaveSolutions/docgen/pull/30) + [PR #32](https://github.com/SpillwaveSolutions/docgen/pull/32) (wiring follow-up) |
 | [#8](https://github.com/SpillwaveSolutions/docgen/issues/8)   | closed | [PR #21](https://github.com/SpillwaveSolutions/docgen/pull/21) |
-| [#9](https://github.com/SpillwaveSolutions/docgen/issues/9)   | open   | — |
+| [#9](https://github.com/SpillwaveSolutions/docgen/issues/9)   | closed | [PR #29](https://github.com/SpillwaveSolutions/docgen/pull/29) |
 | [#10](https://github.com/SpillwaveSolutions/docgen/issues/10) | closed | [PR #23](https://github.com/SpillwaveSolutions/docgen/pull/23) |
 | [#11](https://github.com/SpillwaveSolutions/docgen/issues/11) | closed | [PR #27](https://github.com/SpillwaveSolutions/docgen/pull/27) |
 | [#12](https://github.com/SpillwaveSolutions/docgen/issues/12) | closed | [PR #25](https://github.com/SpillwaveSolutions/docgen/pull/25) |


### PR DESCRIPTION
Status-table update after batch 3 landed (PRs #29, #30, #31, #32). 9 of 13 ULTRAREVIEW tickets closed; 4 open (#13, #15, #17, #18).