### PR TITLE
chore: silent-failure cleanup (4 sub-items)

### DIFF
--- a/src/designdoc/hil.py
+++ b/src/designdoc/hil.py
@@ -12,10 +12,13 @@ from __future__ import annotations
 
 from dataclasses import asdict, dataclass, field
 from datetime import UTC, datetime
+from io import StringIO
 from pathlib import Path
 from typing import Literal
 
 from ruamel.yaml import YAML
+
+from designdoc.io_utils import atomic_write
 
 HILStatus = Literal["open", "resolved"]
 
@@ -75,5 +78,9 @@ def append_issue(path: Path, issue: HILIssue) -> None:
     doc["issues"].append(asdict(issue))
     doc["unresolved_count"] = sum(1 for i in doc["issues"] if i["status"] == "open")
     doc["generated_at"] = datetime.now(UTC).isoformat(timespec="seconds")
-    with path.open("w") as f:
-        _yaml().dump(doc, f)
+    # Atomic .tmp-then-replace via io_utils, matching the rest of the project.
+    # ruamel writes to a stream, so capture into a buffer then hand the string
+    # to atomic_write.
+    buf = StringIO()
+    _yaml().dump(doc, buf)
+    atomic_write(path, buf.getvalue())

--- a/src/designdoc/resolve.py
+++ b/src/designdoc/resolve.py
@@ -14,9 +14,12 @@ from __future__ import annotations
 
 import json
 import re
+from io import StringIO
 from pathlib import Path
 
 from ruamel.yaml import YAML
+
+from designdoc.io_utils import atomic_write
 
 HIL_COMMENT_RE = re.compile(r"<!-- HIL: (HIL-\d+)[^>]*-->")
 
@@ -34,8 +37,11 @@ def load_hil_yaml(path: Path) -> dict:
 def save_hil_yaml(path: Path, doc: dict) -> None:
     y = YAML()
     y.indent(mapping=2, sequence=4, offset=2)
-    with path.open("w") as f:
-        y.dump(doc, f)
+    # Atomic .tmp-then-replace via io_utils. ruamel writes to a stream; capture
+    # into a buffer first.
+    buf = StringIO()
+    y.dump(doc, buf)
+    atomic_write(path, buf.getvalue())
 
 
 def emit_questions(hil_yaml: Path, output_dir: Path) -> dict:

--- a/src/designdoc/stages/s2_file_analysis.py
+++ b/src/designdoc/stages/s2_file_analysis.py
@@ -13,6 +13,9 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
+
+from pydantic import ValidationError
 
 from designdoc.agents.file_analyzer import FileSummary, build_prompt, make_file_analyzer
 from designdoc.io_utils import atomic_write
@@ -20,6 +23,8 @@ from designdoc.loop import doer_schema_loop
 from designdoc.stages._common import current_source_hashes, unwrap_taskgroup_exception
 from designdoc.stages.s1_index import OUTPUT_FILENAME as STAGE1_FILENAME
 from designdoc.state import PipelineState, StageStatus, state_lock
+
+log = logging.getLogger(__name__)
 
 STAGE_NAME = "file_analysis"
 OUTPUT_FILENAME = "stage2_summaries.json"
@@ -150,13 +155,20 @@ def _load_reusable_summaries(
 
 
 def _parse_or_placeholder(text: str, path: str) -> dict:
+    placeholder = {
+        "purpose": f"(HIL: summary for {path} disputed — see hil-issues.yaml)",
+        "key_types": [],
+        "key_functions": [],
+        "external_deps": [],
+        "notes": "unresolved",
+    }
     try:
         return FileSummary.model_validate_json(text).model_dump()
+    except ValidationError:
+        # Expected: doer output didn't match schema — placeholder is intended.
+        return placeholder
     except Exception:
-        return {
-            "purpose": f"(HIL: summary for {path} disputed — see hil-issues.yaml)",
-            "key_types": [],
-            "key_functions": [],
-            "external_deps": [],
-            "notes": "unresolved",
-        }
+        # Unexpected (encoding, memory, etc.) — log loud (Invariant 4) but
+        # still return placeholder so the pipeline doesn't halt on a single file.
+        log.exception("_parse_or_placeholder: unexpected exception for %s", path)
+        return placeholder

--- a/src/designdoc/stages/s3_class_docs.py
+++ b/src/designdoc/stages/s3_class_docs.py
@@ -173,10 +173,25 @@ def _class_input_hash(source_sha: str, class_signature: dict) -> str:
 
 
 def _class_doc_path(output_dir: Path, source_path: str, class_name: str) -> Path:
-    """Map a source file + class to an output path under packages/<pkg>/classes/."""
+    """Map a source file + class to an output path under packages/<pkg>/classes/.
+
+    Path-traversal guard: a malicious target-codebase filename like
+    ``../../etc/foo.py`` would otherwise yield a path outside the output
+    tree. After computing the path, assert it resolves under
+    ``output_dir/packages``; raise ``ValueError`` if not.
+    """
     src = Path(source_path)
     # Package = the last directory component of the source path (e.g. "payments")
     # Skip "src" wrappers — they're structural, not semantic packages.
     parts = [p for p in src.parent.parts if p not in ("src", ".", "")]
     pkg = parts[-1] if parts else "root"
-    return output_dir / OUTPUT_SUBDIR / pkg / "classes" / f"{class_name}.md"
+    out_path = output_dir / OUTPUT_SUBDIR / pkg / "classes" / f"{class_name}.md"
+
+    packages_root = (output_dir / OUTPUT_SUBDIR).resolve()
+    if not out_path.resolve().is_relative_to(packages_root):
+        raise ValueError(
+            f"computed class-doc path {out_path.resolve()} escapes {packages_root} "
+            f"(source_path={source_path!r}, class_name={class_name!r}); "
+            "rejecting to prevent path traversal"
+        )
+    return out_path

--- a/src/designdoc/stages/s6_tech_debt.py
+++ b/src/designdoc/stages/s6_tech_debt.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 
 from designdoc.agents.tech_debt import (
     build_crossref_prompt,
@@ -30,6 +31,8 @@ from designdoc.io_utils import atomic_write, sha1_keyed
 from designdoc.loop import doer_checker_loop
 from designdoc.stages._common import unwrap_taskgroup_exception
 from designdoc.state import PipelineState, StageStatus, state_lock
+
+log = logging.getLogger(__name__)
 
 STAGE_NAME = "tech_debt"
 OUTPUT_FILENAME = "TECH_DEBT.md"
@@ -160,7 +163,15 @@ async def run(
 def _parse_report(text: str, dep, disputed: bool) -> dict:
     try:
         data = json.loads(text)
-    except json.JSONDecodeError:
+    except json.JSONDecodeError as e:
+        # Log loud (Invariant 4): the doer returned non-JSON; the row will
+        # be marked "unknown" but the failure isn't silent.
+        log.warning(
+            "_parse_report: JSON decode failed for dep=%s (disputed=%s): %s",
+            dep.name,
+            disputed,
+            e,
+        )
         data = {"name": dep.name, "pinned": dep.pinned, "status": "unknown"}
     data.setdefault("name", dep.name)
     data.setdefault("pinned", dep.pinned)

--- a/tests/unit/test_class_doc_path_traversal.py
+++ b/tests/unit/test_class_doc_path_traversal.py
@@ -1,0 +1,64 @@
+"""Path-traversal guard for s3._class_doc_path (T5.2 from issue #18).
+
+Defense-in-depth: even though the function's design (taking only the last
+directory component of source_path's parent for `pkg`) accidentally
+neutralizes ``../`` in source_path, a maliciously-constructed class_name
+or pkg WOULD escape via path joining (which doesn't normalize until
+``.resolve()``). The explicit guard inside ``_class_doc_path`` raises
+ValueError on any escape, regardless of the attack vector.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from designdoc.stages.s3_class_docs import _class_doc_path
+
+
+def test_happy_path_lands_under_packages(tmp_path: Path) -> None:
+    out = _class_doc_path(tmp_path, "src/payments/gateway.py", "Gateway")
+    packages_root = (tmp_path / "packages").resolve()
+    assert out.resolve().is_relative_to(packages_root)
+    # Last directory component is the "package" — "src" is stripped.
+    assert "payments" in out.parts
+
+
+def test_root_source_path_falls_back_to_root_pkg(tmp_path: Path) -> None:
+    """Files at the source root get pkg='root' — still under packages/."""
+    out = _class_doc_path(tmp_path, "module.py", "Foo")
+    packages_root = (tmp_path / "packages").resolve()
+    assert out.resolve().is_relative_to(packages_root)
+    assert "root" in out.parts
+
+
+def test_source_path_with_traversal_neutralized_by_design(tmp_path: Path) -> None:
+    """Source-path traversal is neutralized by design — only the last directory
+    component is used for the package name. ``../../etc/passwd.py`` becomes
+    pkg='etc', file lands under packages/etc/classes/Evil.md. Documents the
+    contract; the explicit guard remains as defense-in-depth for
+    class_name-based attacks (next test)."""
+    out = _class_doc_path(tmp_path, "../../etc/passwd.py", "Evil")
+    packages_root = (tmp_path / "packages").resolve()
+    assert out.resolve().is_relative_to(packages_root)
+    assert "etc" in out.parts
+
+
+def test_class_name_with_shallow_traversal_lands_inside_packages(tmp_path: Path) -> None:
+    """A shallow class_name traversal like ``../../etc/passwd`` resolves to
+    ``packages/etc/passwd.md`` — still under packages/, so the guard
+    correctly does NOT fire. This documents the boundary."""
+    out = _class_doc_path(tmp_path, "src/foo.py", "../../etc/passwd")
+    packages_root = (tmp_path / "packages").resolve()
+    assert out.resolve().is_relative_to(packages_root)
+
+
+def test_deeply_nested_class_name_traversal_rejected(tmp_path: Path) -> None:
+    """A class_name containing enough ``../`` steps to escape ``packages/``
+    triggers the guard. From ``packages/<pkg>/classes/`` it takes 3 steps
+    to escape; this attack vector isn't reachable in production (class_name
+    comes from Python AST, restricted to valid identifiers) but the guard
+    is cheap defense for any future caller that forwards untrusted strings."""
+    with pytest.raises(ValueError, match="escapes"):
+        _class_doc_path(tmp_path, "src/foo.py", "../../../tmp/anywhere")


### PR DESCRIPTION
## Summary

4 silent-failure hardening items from the 2026-04-22 ULTRAREVIEW Tier 5 list, bundled in one PR per the issue's design.

## Why

Discovered during the silent-failure pass. None are HIGH severity — the project is clean on shell injection, secrets, and broad-except. These are MED-severity diagnostics improvements that strengthen Invariant 4 ("fail loud, not quiet").

## Changes

- **T5.1** `s2_file_analysis.py:_parse_or_placeholder` — splits the bare `except Exception:` into `except ValidationError:` (expected-placeholder path) and `except Exception:` (logs unexpected via `log.exception`). Placeholder shape preserved exactly (`purpose / key_types / key_functions / external_deps / notes` — no spurious `path` key, which would have broken `FileSummary.model_dump()` parity).

- **T5.2** `s3_class_docs.py:_class_doc_path` — adds path-traversal guard via `Path.is_relative_to`. New `tests/unit/test_class_doc_path_traversal.py` covers:
  - Happy path lands under `packages/`
  - Root-package fallback
  - Documents that source_path-traversal is **neutralized by design** (`_class_doc_path` only uses the LAST directory component for `pkg`, so `../../etc/foo.py` becomes `packages/etc/classes/...`)
  - Documents the shallow class_name traversal boundary (lands at `packages/etc/passwd.md`, still inside)
  - Asserts the guard fires on deeply-nested class_name traversal that would actually escape

- **T5.3** `s6_tech_debt.py:_parse_report` — adds module logger; `log.warning(...)` on `JSONDecodeError`. The fallback row (status=unknown) is unchanged; failures are now visible.

- **T5.4** `hil.py:append_issue` and `resolve.py:save_hil_yaml` — switch from bare `path.open("w") + ruamel.YAML.dump(stream)` to `atomic_write(path, buf.getvalue())` via `StringIO` capture. Aligns with the project's existing atomic-write pattern.

## Invariants

- [x] MAX_ATTEMPTS=3 preserved
- [x] Checker isolation preserved
- [x] Schema-validated verdicts preserved
- [x] Mermaid two-checker preserved
- [x] HIL fallback preserved (T5.4 hardens the YAML write path; semantic behavior unchanged)
- **Invariant 4 strengthened** by T5.1 (narrow except + log) and T5.3 (log JSONDecodeError).

## Verification

- [x] `task ci` green — 100 tests passed in 72.05s
- [x] 5 new traversal tests cover happy path + boundary documentation + actual escape rejection
- [x] TWRC discipline followed

## Related

Closes #18.