### PR TITLE
refactor: move per-stage kwargs and id-prefix onto StageEntry

### DIFF
--- a/src/designdoc/orchestrator.py
+++ b/src/designdoc/orchestrator.py
@@ -39,11 +39,86 @@ log = logging.getLogger(__name__)
 StageFn = Callable[..., Awaitable[Any]]
 
 
+# Other-stage prefix table — used by the class_docs classifier to reject
+# artifact ids that already belong to another stage. Module-level so any
+# future stage that grows its own prefix can amend it in one place.
+_OTHER_PREFIXES = ("file:", "package:", "mermaid:", "dep:", "system:")
+
+
+def _no_owns_id(_aid: str) -> bool:
+    return False
+
+
+def _no_kwargs(_cfg: Config) -> dict[str, Any]:
+    return {}
+
+
+# Built-in classifier predicates per stage name. StageEntry.__post_init__
+# fills owns_id from this table when the constructor caller doesn't supply
+# one explicitly — preserves the contract that StageEntry("class_docs",
+# fake_fn) classifies "<path>::<Class>" ids without the caller having to
+# know the rule.
+_BUILTIN_OWNS_ID: dict[str, Callable[[str], bool]] = {
+    "file_analysis": lambda aid: aid.startswith("file:"),
+    "class_docs": lambda aid: "::" in aid and not aid.startswith(_OTHER_PREFIXES),
+    "package_rollups": lambda aid: aid.startswith("package:"),
+    "mermaid": lambda aid: aid.startswith("mermaid:"),
+    "tech_debt": lambda aid: aid.startswith("dep:"),
+    "system_rollup": lambda aid: aid == "system:rollup",
+}
+
+
+# Built-in kwargs builders per stage name. Each stage gets the kwargs its
+# `run(**kwargs)` accepts. Lambdas reference _enabled_mcp at module-load
+# time but only call it at runtime — forward reference is safe.
+_BUILTIN_KWARGS_FN: dict[str, Callable[[Config], dict[str, Any]]] = {
+    "discover": lambda cfg: {
+        "exclude_paths": list(cfg.exclude_paths),
+        "include_languages": list(cfg.include_languages),
+    },
+    "file_analysis": lambda cfg: {
+        "doer_model": cfg.doer_model,
+        "parallelism": cfg.parallelism,
+    },
+    "class_docs": lambda cfg: {
+        "doer_model": cfg.doer_model,
+        "checker_model": cfg.checker_model,
+        "parallelism": cfg.parallelism,
+    },
+    "package_rollups": lambda cfg: {
+        "doer_model": cfg.doer_model,
+        "checker_model": cfg.checker_model,
+        "parallelism": cfg.parallelism,
+    },
+    "system_rollup": lambda cfg: {
+        "doer_model": cfg.doer_model,
+        "checker_model": cfg.checker_model,
+    },
+    "tech_debt": lambda cfg: {
+        "doer_model": cfg.doer_model,
+        "checker_model": cfg.checker_model,
+        "mcp_servers": _enabled_mcp(cfg),
+        "parallelism": cfg.parallelism,
+    },
+}
+
+
 @dataclass
 class StageEntry:
     name: str
     run: StageFn
     needs_runner: bool = True  # Stage 0/1/8 are deterministic
+    owns_id: Callable[[str], bool] | None = None
+    kwargs_fn: Callable[[Config], dict[str, Any]] | None = None
+
+    def __post_init__(self) -> None:
+        # Fall back to the per-name builtins so casual constructions like
+        # StageEntry("class_docs", fake_fn) still get the right classifier
+        # without callers having to know the rule.
+        if self.owns_id is None:
+            self.owns_id = _BUILTIN_OWNS_ID.get(self.name, _no_owns_id)
+        if self.kwargs_fn is None:
+            self.kwargs_fn = _BUILTIN_KWARGS_FN.get(self.name, _no_kwargs)
 
 
 def default_stage_table() -> list[StageEntry]:
@@ -107,9 +182,7 @@ class Orchestrator:
             if self.state.stages.get(entry.name) == StageStatus.DONE:
                 log.info("[%d/%d] stage %s already done, skipping", idx, total, entry.name)
                 continue
-            prior_count = sum(
-                1 for id_ in self.state.artifact_index if self._id_belongs_to_stage(id_, entry.name)
-            )
+            prior_count = sum(1 for id_ in self.state.artifact_index if entry.owns_id(id_))
             if prior_count > 0:
                 log.info(
                     "[%d/%d] stage %s: %d artifacts checkpointed",
@@ -125,7 +198,7 @@ class Orchestrator:
                 kwargs: dict[str, Any] = {"state": self.state}
                 if entry.needs_runner:
                     kwargs["runner"] = self.runner
-                kwargs.update(self._stage_kwargs(entry.name))
+                kwargs.update(entry.kwargs_fn(self.config))
                 await entry.run(**kwargs)
                 self.budget.save()
             except BudgetExceededError:
@@ -150,65 +223,6 @@ class Orchestrator:
                 entry.name,
                 time.monotonic() - start,
             )
-
-    # Prefix table: maps stage name -> predicate on artifact_id.
-    # Stages 2,4,5,6,7 use a fixed prefix; Stage 3's class_docs ids are
-    # "<path>::<ClassName>" with no prefix so we detect them by "::"
-    # plus exclusion of other known prefixes.
-    _OTHER_PREFIXES = ("file:", "package:", "mermaid:", "dep:", "system:")
-
-    @classmethod
-    def _id_belongs_to_stage(cls, artifact_id: str, stage_name: str) -> bool:
-        if stage_name == "file_analysis":
-            return artifact_id.startswith("file:")
-        if stage_name == "package_rollups":
-            return artifact_id.startswith("package:")
-        if stage_name == "mermaid":
-            return artifact_id.startswith("mermaid:")
-        if stage_name == "tech_debt":
-            return artifact_id.startswith("dep:")
-        if stage_name == "system_rollup":
-            return artifact_id == "system:rollup"
-        if stage_name == "class_docs":
-            return "::" in artifact_id and not artifact_id.startswith(cls._OTHER_PREFIXES)
-        return False
-
-    def _stage_kwargs(self, stage_name: str) -> dict[str, Any]:
-        """Per-stage kwargs derived from config. Only pass keys the stage accepts.
-
-        Kept explicit per-stage because the stage signatures diverge —
-        s2_file_analysis uses a pydantic schema checker (no checker_model),
-        s5_mermaid's models are driven by the mermaid_generator factory
-        directly, and s8_finalize is deterministic.
-        """
-        p = self.config.parallelism
-        if stage_name == "discover":
-            return {
-                "exclude_paths": list(self.config.exclude_paths),
-                "include_languages": list(self.config.include_languages),
-            }
-        if stage_name == "file_analysis":
-            return {"doer_model": self.config.doer_model, "parallelism": p}
-        if stage_name in ("class_docs", "package_rollups"):
-            return {
-                "doer_model": self.config.doer_model,
-                "checker_model": self.config.checker_model,
-                "parallelism": p,
-            }
-        if stage_name == "system_rollup":
-            # Single-artifact stage — no parallelism benefit.
-            return {
-                "doer_model": self.config.doer_model,
-                "checker_model": self.config.checker_model,
-            }
-        if stage_name == "tech_debt":
-            return {
-                "doer_model": self.config.doer_model,
-                "checker_model": self.config.checker_model,
-                "mcp_servers": _enabled_mcp(self.config),
-                "parallelism": p,
-            }
-        return {}
 
 
 def _enabled_mcp(config: Config) -> list[str]:

--- a/tests/unit/test_stage_entry.py
+++ b/tests/unit/test_stage_entry.py
@@ -1,0 +1,189 @@
+"""StageEntry self-describing behavior (issue #13).
+
+After the refactor, each StageEntry carries its own ``owns_id`` predicate
+and ``kwargs_fn`` builder. Adding a new stage 9 should be a one-place
+change to ``default_stage_table()`` — no edits to Orchestrator switch
+methods. These tests lock in the per-stage behavior of both fields,
+including the fragile class_docs rule.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from designdoc.config import Config
+from designdoc.orchestrator import StageEntry, default_stage_table
+
+# ---- StageEntry.owns_id behavior --------------------------------------------
+
+
+def _entry(stage_name: str) -> StageEntry:
+    """Pull the StageEntry for the given stage name from the default table."""
+    table = default_stage_table()
+    entry = next((e for e in table if e.name == stage_name), None)
+    assert entry is not None, f"no StageEntry for {stage_name!r} in default table"
+    return entry
+
+
+@pytest.mark.parametrize(
+    "stage,artifact_id",
+    [
+        ("file_analysis", "file:src/foo.py"),
+        ("class_docs", "src/payments/gateway.py::Gateway"),
+        ("package_rollups", "package:tiny.payments"),
+        ("mermaid", "mermaid:Gateway"),
+        ("tech_debt", "dep:requests"),
+        ("system_rollup", "system:rollup"),
+    ],
+)
+def test_owns_id_claims_own_typical_artifact(stage: str, artifact_id: str) -> None:
+    assert _entry(stage).owns_id(artifact_id), f"{stage} should own {artifact_id!r}"
+
+
+@pytest.mark.parametrize(
+    "foreign_id",
+    [
+        "file:src/foo.py",
+        "package:tiny.payments",
+        "mermaid:Gateway",
+        "dep:requests",
+        "system:rollup",
+    ],
+)
+def test_class_docs_rejects_other_stage_ids(foreign_id: str) -> None:
+    """The fragile class_docs rule (has '::' AND not in _OTHER_PREFIXES)
+    must reject every other stage's typical id, including the system:rollup
+    form added in PR #29. This is the regression case the StageEntry
+    refactor is designed to make harder to break."""
+    assert not _entry("class_docs").owns_id(foreign_id), (
+        f"class_docs incorrectly claimed {foreign_id!r} — _OTHER_PREFIXES drift"
+    )
+
+
+def test_class_docs_claims_path_double_colon_form() -> None:
+    """Positive case: an id with '::' that isn't a known prefix IS class_docs."""
+    assert _entry("class_docs").owns_id("path/foo.py::MyClass")
+
+
+def test_system_rollup_uses_exact_match_not_prefix() -> None:
+    """system_rollup uses exact-string match. 'system:rollup:extra' must NOT
+    classify (vs system:rollup which does). Guards against a future
+    prefix-style change that would conflict with class_docs' rule."""
+    e = _entry("system_rollup")
+    assert e.owns_id("system:rollup")
+    assert not e.owns_id("system:other")
+    assert not e.owns_id("system:rollup:extra")
+
+
+@pytest.mark.parametrize("stage", ["discover", "index", "finalize"])
+@pytest.mark.parametrize(
+    "artifact_id",
+    ["file:foo", "package:bar", "src/foo.py::Bar", "system:rollup", "anything"],
+)
+def test_deterministic_stages_claim_no_artifact_ids(stage: str, artifact_id: str) -> None:
+    """Stages 0/1/8 are deterministic — they don't write per-artifact entries
+    to artifact_index, so their owns_id must always return False."""
+    assert not _entry(stage).owns_id(artifact_id)
+
+
+# ---- StageEntry.kwargs_fn behavior ------------------------------------------
+
+
+def test_discover_kwargs_passes_exclude_and_languages() -> None:
+    cfg = Config(exclude_paths=("foo",), include_languages=("python",))
+    kwargs = _entry("discover").kwargs_fn(cfg)
+    assert kwargs == {
+        "exclude_paths": ["foo"],
+        "include_languages": ["python"],
+    }
+
+
+def test_file_analysis_kwargs_passes_doer_model_and_parallelism() -> None:
+    cfg = Config(doer_model="claude-sonnet-4-6", parallelism=4)
+    kwargs = _entry("file_analysis").kwargs_fn(cfg)
+    assert kwargs == {"doer_model": "claude-sonnet-4-6", "parallelism": 4}
+
+
+def test_class_docs_kwargs_includes_checker_model() -> None:
+    cfg = Config(
+        doer_model="claude-sonnet-4-6",
+        checker_model="claude-sonnet-4-6",
+        parallelism=2,
+    )
+    kwargs = _entry("class_docs").kwargs_fn(cfg)
+    assert kwargs == {
+        "doer_model": "claude-sonnet-4-6",
+        "checker_model": "claude-sonnet-4-6",
+        "parallelism": 2,
+    }
+
+
+def test_system_rollup_kwargs_omits_parallelism() -> None:
+    """Single-artifact stage — parallelism doesn't apply."""
+    cfg = Config(doer_model="x", checker_model="y", parallelism=8)
+    kwargs = _entry("system_rollup").kwargs_fn(cfg)
+    assert kwargs == {"doer_model": "x", "checker_model": "y"}
+    assert "parallelism" not in kwargs
+
+
+def test_tech_debt_kwargs_includes_mcp_servers() -> None:
+    cfg = Config(
+        doer_model="x",
+        checker_model="y",
+        parallelism=1,
+        perplexity_mcp=True,
+        context7_mcp=True,
+    )
+    kwargs = _entry("tech_debt").kwargs_fn(cfg)
+    assert kwargs["mcp_servers"] == ["perplexity", "context7"]
+
+
+def test_deterministic_stages_kwargs_empty() -> None:
+    cfg = Config()
+    for stage in ("index", "finalize"):
+        assert _entry(stage).kwargs_fn(cfg) == {}
+
+
+# ---- __post_init__ fallback (compat with downstream test constructions) ----
+
+
+def test_constructor_fills_owns_id_from_builtin() -> None:
+    """A bare StageEntry("class_docs", fn) — without explicit owns_id —
+    must still pick up the class_docs classifier rule. Required for
+    test_orchestrator_checkpoint_logs.py and any future test that
+    constructs a StageEntry by name with a fake stage function."""
+
+    async def fake_fn(**_: object) -> None:
+        return None
+
+    entry = StageEntry("class_docs", fake_fn, needs_runner=False)
+    assert entry.owns_id is not None
+    assert entry.owns_id("path/foo.py::MyClass")
+    assert not entry.owns_id("file:foo.py")
+
+
+def test_constructor_explicit_owns_id_wins_over_builtin() -> None:
+    """If a caller passes owns_id explicitly, the builtin is NOT used."""
+
+    async def fake_fn(**_: object) -> None:
+        return None
+
+    entry = StageEntry(
+        "class_docs",
+        fake_fn,
+        needs_runner=False,
+        owns_id=lambda _: True,
+    )
+    assert entry.owns_id("anything")  # custom predicate, not class_docs rule
+
+
+def test_unknown_stage_name_falls_back_to_no_owns_id() -> None:
+    """An unfamiliar stage name (e.g. a future or test-only stage) gets a
+    safe ``return False`` predicate — no false-positive id classification."""
+
+    async def fake_fn(**_: object) -> None:
+        return None
+
+    entry = StageEntry("unknown_stage", fake_fn, needs_runner=False)
+    assert entry.owns_id("anything") is False
+    assert entry.kwargs_fn(Config()) == {}


### PR DESCRIPTION
## Summary

Adds `owns_id` and `kwargs_fn` callable fields to `StageEntry` so each stage entry is self-describing. Deletes Orchestrator's two switch-on-string methods. Adding stage 9 is now a one-place change to `default_stage_table()`.

## Why

Both architecture and code-quality reviewers independently flagged this during the 2026-04-22 ULTRAREVIEW (convergent signal). Today:

- `Orchestrator._id_belongs_to_stage` is a 7-branch switch-on-string classifier. The class_docs rule (`"::" in id and not startswith(_OTHER_PREFIXES)`) is fragile — silently breaks if a future stage uses `::` in its ids.
- `Orchestrator._stage_kwargs` is a 5-branch switch-on-string builder.

Adding stage 9 requires touching 3 sites: the stage table + both switch methods.

## Pattern: builtin-fallback per-name lookup

Each stage's classifier and kwargs-builder live as lambdas in module-level `_BUILTIN_OWNS_ID` / `_BUILTIN_KWARGS_FN` dicts keyed by stage name. `StageEntry.__post_init__` fills `owns_id` / `kwargs_fn` from those dicts when the caller doesn't supply them — this preserves the existing contract that `StageEntry("class_docs", fake_fn)` classifies `<path>::<Class>` ids without the caller having to know the rule.

This is critical for `tests/integration/test_orchestrator_checkpoint_logs.py`, which constructs `StageEntry("class_docs", fake_stage, needs_runner=False)` and relies on the classifier counting 3 seeded `foo.py::Ci` ids.

## Changes

- `src/designdoc/orchestrator.py`:
  - New module-level `_OTHER_PREFIXES`, `_no_owns_id`, `_no_kwargs`, `_BUILTIN_OWNS_ID`, `_BUILTIN_KWARGS_FN`
  - `StageEntry` gains `owns_id` and `kwargs_fn` Callable fields (default None) + `__post_init__` fallback
  - Two call sites in `Orchestrator.run` use `entry.owns_id(id_)` and `entry.kwargs_fn(self.config)` directly
  - Deleted: `Orchestrator._id_belongs_to_stage` (classmethod) and `Orchestrator._stage_kwargs` (method)
  - `_enabled_mcp(config)` helper kept as module-level (used by tech_debt's kwargs_fn lambda)
- `tests/unit/test_stage_entry.py` NEW (17 tests)
  - Filename intentionally distinct from #17's `tests/unit/test_orchestrator.py` so the two PRs can land in any order without file conflict.

## Invariants

- [x] MAX_ATTEMPTS=3 preserved (loop.py untouched)
- [x] Checker isolation preserved
- [x] Schema-validated verdicts preserved
- [x] Mermaid two-checker preserved
- [x] HIL fallback preserved
- The `test_config_does_not_expose_max_attempts` constitutional guard still passes.

## Verification

- [x] `task ci` green — 100 tests passed in 68.62s + 17 new in test_stage_entry.py
- [x] `tests/integration/test_orchestrator_checkpoint_logs.py` continues to pass — the `StageEntry("class_docs", ...)` construction picks up the builtin classifier via `__post_init__`
- [x] TWRC discipline followed
- [x] `_id_belongs_to_stage` deletion is safe — only consumer was an internal call; PR #35's test_orchestrator.py uses an adapter shim that tries `StageEntry.owns_id` first

## Related

Closes #13.