### PR TITLE
chore: close out ULTRAREVIEW follow-up — 13/13 tickets shipped

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,9 +95,6 @@ is a record of merged PRs, not in-progress work.
   closeable; "task ci green on test X" is.
 - **Labels** follow `.github/ISSUE_TEMPLATE/`: `bug`, `enhancement`, `investigation`.
 
-**Active follow-up work:** see `plans/2026_04_22_ultrareview_followup.md`
-(issues #6-#18, opened from the 2026-04-22 ULTRAREVIEW pass).
-
 ## Specs live under `./plans/`
 
 | Path | Contents |

--- a/plans/archive/2026_04_22_ultrareview_followup.md
+++ b/plans/archive/2026_04_22_ultrareview_followup.md
@@ -52,6 +52,8 @@ Issue # column is back-filled in a separate PR after issue creation.
 
 ## Status tracking
 
+**Final status: 13/13 closed (2026-04-24).** Plan archived.
+
 | Issue | Status | Closed by |
 |---|---|---|
 | [#6](https://github.com/SpillwaveSolutions/docgen/issues/6)   | closed | [PR #31](https://github.com/SpillwaveSolutions/docgen/pull/31) |
@@ -61,12 +63,12 @@ Issue # column is back-filled in a separate PR after issue creation.
 | [#10](https://github.com/SpillwaveSolutions/docgen/issues/10) | closed | [PR #23](https://github.com/SpillwaveSolutions/docgen/pull/23) |
 | [#11](https://github.com/SpillwaveSolutions/docgen/issues/11) | closed | [PR #27](https://github.com/SpillwaveSolutions/docgen/pull/27) |
 | [#12](https://github.com/SpillwaveSolutions/docgen/issues/12) | closed | [PR #25](https://github.com/SpillwaveSolutions/docgen/pull/25) |
-| [#13](https://github.com/SpillwaveSolutions/docgen/issues/13) | open   | — |
+| [#13](https://github.com/SpillwaveSolutions/docgen/issues/13) | closed | [PR #37](https://github.com/SpillwaveSolutions/docgen/pull/37) |
 | [#14](https://github.com/SpillwaveSolutions/docgen/issues/14) | closed | [PR #26](https://github.com/SpillwaveSolutions/docgen/pull/26) |
-| [#15](https://github.com/SpillwaveSolutions/docgen/issues/15) | open   | — |
+| [#15](https://github.com/SpillwaveSolutions/docgen/issues/15) | closed | [PR #34](https://github.com/SpillwaveSolutions/docgen/pull/34) |
 | [#16](https://github.com/SpillwaveSolutions/docgen/issues/16) | closed | [PR #22](https://github.com/SpillwaveSolutions/docgen/pull/22) |
-| [#17](https://github.com/SpillwaveSolutions/docgen/issues/17) | open   | — |
-| [#18](https://github.com/SpillwaveSolutions/docgen/issues/18) | open   | — |
+| [#17](https://github.com/SpillwaveSolutions/docgen/issues/17) | closed | [PR #35](https://github.com/SpillwaveSolutions/docgen/pull/35) |
+| [#18](https://github.com/SpillwaveSolutions/docgen/issues/18) | closed | [PR #36](https://github.com/SpillwaveSolutions/docgen/pull/36) |
 
 When a PR lands and closes its issue, replace `open` with `closed` and fill
 in the PR number. When all 13 are closed, delete this file and the related


### PR DESCRIPTION
## Summary

Closes out the 2026-04-22 ULTRAREVIEW follow-up plan. All 13 tickets shipped via PRs #21-#37.

## Why

Per the plan's own Step 5 close-out ritual ("no zombie plans"):

- Move `plans/2026_04_22_ultrareview_followup.md` → `plans/archive/` so a future contributor scanning `plans/` doesn't think it's still in flight.
- Remove the "Active follow-up work" pointer from `CONTRIBUTING.md`.
- Update the archived plan's status table with the final closing-PR mapping for the last batch (#13, #15, #17, #18).

## Final ticket-to-PR map

| Ticket | Closed by |
|---|---|
| #6 budget leak | PR #31 |
| #7 split total_retries | PR #30 + #32 (wiring follow-up) |
| #8 atomic_write s0/s1/s7 | PR #21 |
| #9 stage 7 checkpoint | PR #29 |
| #10 state_lock | PR #23 |
| #11 sha1_keyed | PR #27 |
| #12 dedupe _current_source_hashes | PR #25 |
| #13 StageEntry self-describing | PR #37 |
| #14 _ship_with_hil | PR #26 |
| #15 MermaidIssue wired | PR #34 |
| #16 polish pass | PR #22 |
| #17 guard tests | PR #35 |
| #18 silent-failure cleanup | PR #36 |

## Verification

- [x] `gh issue list --repo SpillwaveSolutions/docgen --state open` returns empty (no ULTRAREVIEW tickets remain open)
- [x] All branches deleted post-merge; remote pruned
- [x] `task ci` continues green on main

## Related

This PR doesn't close an issue — it's the final close-out artifact. Build on PRs #21-#37.