### PR TITLE
chore: distribution setup — marketplace plugin + git+ install + publish-on-tag

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "designdoc",
+  "description": "Spillwave designdoc — harness-engineered codebase documentation pipeline as a Claude Code plugin",
+  "owner": {
+    "name": "Spillwave Solutions",
+    "url": "https://github.com/SpillwaveSolutions"
+  },
+  "plugins": [
+    {
+      "name": "designdoc",
+      "description": "Walks a repo and emits a validated docs/design/ tree (class docs, package rollups, mermaid diagrams, tech-debt ledger). Slash command: /designdoc [generate|resume|status|resolve].",
+      "version": "1.2.0",
+      "source": "./plugins/designdoc",
+      "author": {
+        "name": "Rick Hightower",
+        "url": "https://github.com/SpillwaveSolutions"
+      }
+    }
+  ]
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,120 @@
+name: release
+
+# Triggered ONLY on version tag push (e.g. `git tag v1.2.1 && git push origin v1.2.1`).
+# - Reruns the CI gate (lint + tests) so we never publish a wheel that wouldn't pass main.
+# - Guards that the git tag matches `version = "..."` in pyproject.toml.
+# - Builds wheel + sdist with `uv build`.
+# - Publishes to PyPI via Trusted Publishing (OIDC, no long-lived token in repo secrets).
+# - Creates a GitHub Release with auto-generated notes.
+#
+# One-time setup required on the PyPI side (see CONTRIBUTING.md → "Releasing"):
+#   PyPI → Account settings → Publishing → Add a new pending publisher:
+#     PyPI Project Name: designdoc
+#     Owner:             SpillwaveSolutions
+#     Repository name:   docgen
+#     Workflow name:     release.yml
+#     Environment name:  pypi
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Version tag to release (must already exist, e.g. v1.2.1). Used for manual reruns.'
+        required: true
+
+permissions:
+  contents: write    # for GitHub Release creation
+  id-token: write    # for PyPI Trusted Publishing OIDC
+
+jobs:
+  ci:
+    # Mirror of test.yml — keeps the CI-parity rule honest. If someone changes
+    # test.yml, this rerun catches the divergence before the wheel ships.
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Set up Node (for @mermaid-js/mermaid-cli)
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Warm mmdc cache
+        run: npx --yes @mermaid-js/mermaid-cli --version
+        timeout-minutes: 5
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Lint (ruff check)
+        run: uv run ruff check src tests
+
+      - name: Format check (ruff format --check)
+        run: uv run ruff format --check src tests
+
+      - name: Unit tests
+        run: uv run pytest tests/unit -v
+
+      - name: Integration tests (no API)
+        run: uv run pytest tests/integration -m "not requires_api" -v
+
+  build-and-publish:
+    needs: ci
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment:
+      name: pypi
+      url: https://pypi.org/p/designdoc
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      - name: Verify tag matches pyproject.toml version
+        run: |
+          # workflow_dispatch passes the tag as input; tag push uses GITHUB_REF_NAME.
+          TAG="${{ github.event.inputs.tag || github.ref_name }}"
+          TAG_VERSION="${TAG#v}"
+          PYPROJECT_VERSION=$(grep -E '^version = ' pyproject.toml | head -1 | sed -E 's/version = "([^"]+)"/\1/')
+          echo "tag=$TAG_VERSION pyproject=$PYPROJECT_VERSION"
+          if [ "$TAG_VERSION" != "$PYPROJECT_VERSION" ]; then
+            echo "::error::tag $TAG (=> $TAG_VERSION) does not match pyproject.toml version $PYPROJECT_VERSION"
+            exit 1
+          fi
+
+      - name: Build wheel + sdist
+        run: uv build
+
+      - name: Publish to PyPI (Trusted Publishing)
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # No `password:` — Trusted Publishing uses OIDC.
+          packages-dir: dist/
+          # Don't fail if the same version is already on PyPI; lets us re-run
+          # workflow_dispatch idempotently.
+          skip-existing: true
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.event.inputs.tag || github.ref_name }}
+          generate_release_notes: true
+          files: dist/*

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -132,3 +132,58 @@ task dogfood  # live pipeline against tests/fixtures/tiny_repo
 ```
 
 See `README.md` for user-facing usage.
+
+## Releasing
+
+We use **PyPI Trusted Publishing** (OIDC) — no long-lived API token sits in
+GitHub secrets. The release workflow lives at `.github/workflows/release.yml`.
+
+### One-time PyPI side setup
+
+Before the first release can publish successfully, register a Trusted Publisher
+on PyPI:
+
+1. Sign in at <https://pypi.org/> with the account that will own the project.
+2. Go to **Account settings → Publishing → Add a new pending publisher**.
+3. Fill in:
+   - **PyPI Project Name:** `designdoc`
+   - **Owner:** `SpillwaveSolutions`
+   - **Repository name:** `docgen`
+   - **Workflow name:** `release.yml`
+   - **Environment name:** `pypi`
+4. Save. The first successful publish from the workflow will claim the project name.
+
+Also create a GitHub Actions environment named `pypi` (Repo → Settings →
+Environments → New environment → `pypi`). The workflow's
+`build-and-publish` job is gated on this environment so reviewers can require
+manual approval before publishing if desired.
+
+### Cutting a release
+
+```bash
+# 1. Bump the version in pyproject.toml (e.g. 1.2.0 → 1.2.1).
+#    The release workflow refuses to publish if the tag and pyproject version disagree.
+$EDITOR pyproject.toml
+
+# 2. Update CHANGELOG.md with the new version section.
+
+# 3. Commit and merge via PR (no direct main commits — see PR Workflow above).
+
+# 4. After merge, tag the release commit on main:
+git checkout main
+git pull --prune
+git tag -a v1.2.1 -m "v1.2.1"
+git push origin v1.2.1
+```
+
+Tag push triggers `.github/workflows/release.yml`, which:
+
+1. Reruns the CI gate (lint + tests).
+2. Verifies the tag matches `pyproject.toml`'s `version`.
+3. Builds wheel + sdist with `uv build`.
+4. Publishes to PyPI via OIDC Trusted Publishing.
+5. Creates a GitHub Release with auto-generated notes and the built artifacts attached.
+
+If publishing fails partway, fix the cause and re-run the workflow via
+`Actions → release → Run workflow`, supplying the existing tag. The
+`skip-existing: true` flag on the publish step makes re-runs idempotent.

--- a/README.md
+++ b/README.md
@@ -4,9 +4,33 @@ Harness-engineered codebase documentation pipeline.
 
 Walks any repo bottom-up and emits a validated `docs/design/` tree: per-class docs, package rollups, mermaid diagrams (syntax + semantics validated), a system-design rollup, a tech-debt ledger, and a YAML file of unresolved human-in-the-loop disputes.
 
-## Quickstart
+## Install
+
+### As a CLI
+
+Install the `designdoc` command into a uv-managed tool environment:
 
 ```bash
+uv tool install git+https://github.com/SpillwaveSolutions/docgen
+designdoc generate --repo /path/to/your/repo --budget 5.00
+```
+
+(Alternatively, `pipx install git+https://github.com/SpillwaveSolutions/docgen` if you prefer pipx. Once published to PyPI, `pip install designdoc` will also work.)
+
+### As a Claude Code plugin
+
+```bash
+claude plugin marketplace add SpillwaveSolutions/docgen
+claude plugin install designdoc
+```
+
+Adds a `/designdoc` slash command (`generate | resume | status | resolve`).
+
+### From a clone (development)
+
+```bash
+git clone https://github.com/SpillwaveSolutions/docgen
+cd docgen
 uv sync
 uv run designdoc generate --repo /path/to/your/repo --budget 5.00
 ```
@@ -104,10 +128,11 @@ plans/             # implementation plan
 
 ## Claude Code plugin
 
-A `/designdoc` slash command wrapper lives in `plugins/designdoc/` (to be built in Task 21):
+A `/designdoc` slash command wrapper lives in `plugins/designdoc/`. Install via the marketplace path described in [Install](#as-a-claude-code-plugin), or from a local clone:
 
 ```bash
-cp -r plugins/designdoc ~/.claude/plugins/designdoc
+claude plugin marketplace add /path/to/your/clone/of/docgen
+claude plugin install designdoc
 ```
 
 Commands: `/designdoc generate | resume | status | resolve`.

--- a/plugins/designdoc/.claude-plugin/plugin.json
+++ b/plugins/designdoc/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "designdoc",
+  "version": "1.2.0",
+  "description": "Generate validated design documentation for any codebase. Walks a repo bottom-up and emits a docs/design/ tree: per-class docs, package rollups, mermaid diagrams (syntax + semantic validated), tech-debt ledger, system design, and unresolved HIL disputes YAML.",
+  "keywords": ["documentation", "design-docs", "codebase-analysis", "mermaid", "tech-debt", "spillwave"],
+  "author": {
+    "name": "Rick Hightower",
+    "url": "https://github.com/SpillwaveSolutions"
+  },
+  "license": "MIT",
+  "homepage": "https://github.com/SpillwaveSolutions/docgen",
+  "repository": "https://github.com/SpillwaveSolutions/docgen",
+  "commands": ["../commands/designdoc.md"]
+}

--- a/plugins/designdoc/README.md
+++ b/plugins/designdoc/README.md
@@ -4,8 +4,18 @@ Claude Code slash-command wrapper for the [designdoc](../..) CLI.
 
 ## Install
 
+Recommended (Claude Code marketplace):
+
 ```bash
-cp -r plugins/designdoc ~/.claude/plugins/designdoc
+claude plugin marketplace add SpillwaveSolutions/docgen
+claude plugin install designdoc
+```
+
+Or install from a local clone:
+
+```bash
+claude plugin marketplace add /path/to/your/clone/of/docgen
+claude plugin install designdoc
 ```
 
 Then in any Claude Code session:
@@ -19,7 +29,12 @@ Then in any Claude Code session:
 
 ## Prerequisites
 
-- `designdoc` on PATH (`uv tool install .` or `pip install .` from the repo root).
+- `designdoc` on PATH. Install from a clone with `uv tool install .`, or directly from GitHub:
+
+  ```bash
+  uv tool install git+https://github.com/SpillwaveSolutions/docgen
+  ```
+
 - `claude` CLI logged in to a Pro/Max subscription — the SDK uses this CLI
   as its transport. No `ANTHROPIC_API_KEY` needed.
 - `npx` + Node for Stage 5 mermaid validation, or use `--skip mermaid`.

--- a/plugins/designdoc/plugin.json
+++ b/plugins/designdoc/plugin.json
@@ -1,8 +1,0 @@
-{
-  "name": "designdoc",
-  "version": "1.2.0",
-  "description": "Generate validated design documentation for any codebase",
-  "author": "Rick Hightower (Spillwave)",
-  "license": "MIT",
-  "commands": ["./commands/designdoc.md"]
-}

--- a/tests/integration/test_plugin.py
+++ b/tests/integration/test_plugin.py
@@ -3,6 +3,12 @@
 The plugin is a thin shell over the CLI — these tests verify the shipped
 files are well-formed (valid JSON, required frontmatter fields, references
 to $ARGUMENTS + AskUserQuestion) so a broken plugin gets caught in CI.
+
+Layout (Claude Code marketplace convention):
+
+  <repo>/.claude-plugin/marketplace.json   — declares this repo as a marketplace
+  <repo>/plugins/designdoc/.claude-plugin/plugin.json — the plugin manifest
+  <repo>/plugins/designdoc/commands/designdoc.md      — the slash command body
 """
 
 from __future__ import annotations
@@ -10,14 +16,42 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-PLUGIN_ROOT = Path(__file__).parent.parent.parent / "plugins" / "designdoc"
+REPO_ROOT = Path(__file__).parent.parent.parent
+PLUGIN_ROOT = REPO_ROOT / "plugins" / "designdoc"
+MARKETPLACE_JSON = REPO_ROOT / ".claude-plugin" / "marketplace.json"
+PLUGIN_JSON = PLUGIN_ROOT / ".claude-plugin" / "plugin.json"
+
+
+def test_marketplace_json_is_valid_and_lists_designdoc():
+    data = json.loads(MARKETPLACE_JSON.read_text())
+    assert data["name"], "marketplace must have a name"
+    assert isinstance(data.get("plugins"), list) and data["plugins"], (
+        "marketplace must list at least one plugin"
+    )
+    designdoc = next((p for p in data["plugins"] if p.get("name") == "designdoc"), None)
+    assert designdoc is not None, "marketplace must list the designdoc plugin"
+    # source path must point at an existing plugin folder relative to the repo root
+    source = (REPO_ROOT / designdoc["source"]).resolve()
+    assert source == PLUGIN_ROOT.resolve(), (
+        f"plugin source {designdoc['source']} must point to plugins/designdoc"
+    )
+
+
+def test_plugin_json_lives_under_claude_plugin_dir():
+    """Canonical Claude Code plugin layout: manifest under .claude-plugin/."""
+    assert PLUGIN_JSON.exists(), (
+        f"plugin manifest must live at {PLUGIN_JSON.relative_to(REPO_ROOT)} "
+        "(Claude Code marketplace convention)"
+    )
 
 
 def test_plugin_json_is_valid_and_references_command():
-    data = json.loads((PLUGIN_ROOT / "plugin.json").read_text())
+    data = json.loads(PLUGIN_JSON.read_text())
     assert data["name"] == "designdoc"
     assert "version" in data
-    assert data["commands"] == ["./commands/designdoc.md"]
+    assert data["commands"] == ["../commands/designdoc.md"], (
+        "commands path must be relative to plugin.json (../ to escape .claude-plugin/)"
+    )
 
 
 def test_command_file_has_required_frontmatter():


### PR DESCRIPTION
## Summary

Make `designdoc` installable for others without bespoke `cp -r` and `git+` URL incantations.

## Why

Two artifacts ship from this repo: the Python CLI and the Claude Code plugin. Today both require knowing exactly which incantation to type. After this PR:

- `uv tool install git+https://github.com/SpillwaveSolutions/docgen` installs the CLI.
- `claude plugin marketplace add SpillwaveSolutions/docgen && claude plugin install designdoc` installs the plugin.
- `git tag v1.2.1 && git push origin v1.2.1` will (once the PyPI Trusted Publisher is registered) publish the wheel automatically.

This sets up the rails. The first actual PyPI publish (Decision 2B in #39) is intentionally not part of this PR — that remains a deliberate, irreversible action gated on explicit go-ahead.

## Changes

- **Plugin restructure** (`.claude-plugin/` convention).
  - Moved `plugins/designdoc/plugin.json` → `plugins/designdoc/.claude-plugin/plugin.json`.
  - Added `.claude-plugin/marketplace.json` at repo root, listing one plugin (`source: "./plugins/designdoc"`).
  - Updated `tests/integration/test_plugin.py` to assert the new shape (TWRC: failing test written first, made green by the file moves).
- **README updates.**
  - Added user-facing **Install** section to `README.md` covering CLI (uv tool / pipx / future PyPI) and Claude Code plugin (marketplace add) paths.
  - Replaced stale `cp -r plugins/designdoc ~/.claude/plugins/...` instruction in `plugins/designdoc/README.md`.
  - Removed "to be built in Task 21" note since the plugin shipped in v1.2.0.
- **Publish-on-tag workflow** (`.github/workflows/release.yml`).
  - Triggers on `v*.*.*` tag push (or `workflow_dispatch` for manual reruns).
  - Mirrors the `test.yml` CI gate before publishing — never ships a wheel that wouldn't pass main.
  - Verifies tag matches `pyproject.toml`'s `version` (catches the "tagged v1.3.0, forgot to bump pyproject" foot-gun).
  - Builds with `uv build`; publishes to PyPI via **Trusted Publishing** (OIDC, no `PYPI_API_TOKEN` secret).
  - Creates a GitHub Release with auto-generated notes + attached artifacts.
  - `skip-existing: true` makes manual reruns idempotent.
- **CONTRIBUTING.md → Releasing** section documents the one-time PyPI Trusted Publisher registration and the standard release flow.

## Invariants

This PR is pure plugin/CI/docs tooling. No `src/designdoc/` code touched, so the Gen-3 invariants (`MAX_ATTEMPTS=3`, checker isolation, schema-validated verdicts, mermaid two-checker, HIL fallback) are not in scope and remain unchanged.

## Verification

- [x] `task ci` green locally (lint + format-check + unit + integration; 106 integration tests pass).
- [x] New `tests/integration/test_plugin.py` assertions cover both `marketplace.json` shape and the `.claude-plugin/plugin.json` location. Failing test was written first (TWRC).
- [x] CI-parity preserved: `release.yml`'s `ci` job mirrors `test.yml`'s steps verbatim.
- [ ] **Out of scope for this PR:** actual PyPI publish. Workflow only runs if a `v*.*.*` tag is pushed AND the Trusted Publisher is registered on PyPI. Both happen in a follow-up.

## Related

- Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)