### PR TITLE
fix(discover): exclude common tooling dirs (.claude, .opencode, etc.) by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,11 @@ docs/design/.designdoc-budget.json
 # runs; never committed because they change every run with real LLM output.
 tests/fixtures/*/docs/design/
 
+# Local eval runs against external repos — generated docs, never committed.
+docs/agent-brain/
+docs/agent-memory/
+docs/eval/
+
 # IDE
 .idea/
 .vscode/

--- a/src/designdoc/index/discover.py
+++ b/src/designdoc/index/discover.py
@@ -17,6 +17,7 @@ _HASH_CHUNK = 64 * 1024
 
 DEFAULT_EXCLUDES: frozenset[str] = frozenset(
     {
+        # Build outputs and dependency caches.
         "node_modules",
         ".venv",
         "venv",
@@ -28,6 +29,14 @@ DEFAULT_EXCLUDES: frozenset[str] = frozenset(
         ".pytest_cache",
         ".ruff_cache",
         ".mypy_cache",
+        # Modern dev-tooling configs that are commonly committed but are not
+        # the user's product code. Indexing them burns LLM budget on samples
+        # and plugin scaffolds. Issue #42.
+        ".claude",
+        ".opencode",
+        ".devcontainer",
+        ".idea",
+        ".vscode",
     }
 )
 

--- a/tests/unit/test_discover.py
+++ b/tests/unit/test_discover.py
@@ -82,6 +82,33 @@ def test_default_excludes_list_is_documented():
     assert "target" in DEFAULT_EXCLUDES
 
 
+def test_default_excludes_skips_committed_tooling_dirs():
+    """Modern dev workflows commit local tooling configs (.claude, .opencode,
+    .devcontainer, .idea, .vscode). Those are never the user's product code,
+    so we exclude them by default to avoid burning LLM budget on samples and
+    plugin scaffolds. Issue #42.
+    """
+    for d in (".claude", ".opencode", ".devcontainer", ".idea", ".vscode"):
+        assert d in DEFAULT_EXCLUDES, f"{d} must be in DEFAULT_EXCLUDES"
+
+
+def test_excludes_dot_claude_skill_samples(tmp_path: Path):
+    """Regression: agent-brain eval indexed .claude/skills/.../sample-cli/*.py
+    files (Rick's local skill samples). Those got expensive doer/checker
+    treatment despite being unrelated to the codebase under documentation.
+    """
+    _mk(
+        tmp_path,
+        "src/main.py",
+        ".claude/skills/mastering-python-skill/sample-cli/code_validator.py",
+        ".opencode/agent.py",
+    )
+    report = discover(tmp_path)
+    assert report.tree == [Path("src/main.py")]
+    assert all(".claude" not in p.parts for p in report.tree)
+    assert all(".opencode" not in p.parts for p in report.tree)
+
+
 def test_unknown_extensions_ignored(tmp_path: Path):
     _mk(tmp_path, "a.py", "image.png", "data.bin", "README.md")
     report = discover(tmp_path)


### PR DESCRIPTION
## Summary

Add \`.claude\`, \`.opencode\`, \`.devcontainer\`, \`.idea\`, \`.vscode\` to \`DEFAULT_EXCLUDES\` so designdoc stops paying for LLM analysis on committed-but-not-product-code tooling dirs.

## Why

Real-repo eval (designdoc 1.2.0 against agent-brain — see #41 for that run) indexed and paid for 7 file summaries on tooling artifacts: 4 under \`.claude/skills/.../sample-cli/\` (Claude Code skill samples), 3 under \`.opencode/\`. ~$0.85 of $14.99 budget wasted before the run halted mid-Stage-2.

Modern dev workflows commit these configs all the time. Treating them as documentation targets is never what the user wants.

## Changes

- \`src/designdoc/index/discover.py\`: extend \`DEFAULT_EXCLUDES\` with the five tooling dirs.
- \`tests/unit/test_discover.py\`: add \`test_default_excludes_skips_committed_tooling_dirs\` and \`test_excludes_dot_claude_skill_samples\` (regression). Wrote both red first, then made green by the source change (TWRC).
- \`.gitignore\`: bring along the \`docs/agent-brain/\` eval-output ignore I added on a previous branch — keeps the repo clean during local evals.

## Invariants

Pure discover-stage change. No \`loop.py\`, no \`verdict.py\`, no \`mermaid/loop.py\` touched. Gen-3 invariants (MAX_ATTEMPTS=3, checker isolation, schema-validated verdicts, mermaid two-checker, HIL fallback) not in scope.

## Verification

- [x] \`task ci\` green locally — 11 unit + 95 integration tests pass.
- [x] Failing test written first; passes after the discover.py change.
- [x] No behavioral change for users who already pass custom \`exclude_paths\` — those still compose additively (\`discover.py:85-86\`).

## Related

- Closes #42.
- Sibling issue #41 (Stage 2 doer schema-retry rate) is independent and ships in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)