### PR TITLE
fix(runner): plumb target_repo as cwd to SDK subprocess — closes #46 (PyPI blocker)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,10 @@ docs/agent-brain/
 docs/agent-memory/
 docs/eval/
 
+# Stray local-tool scratch dirs that occasionally land in the repo root.
+tmp_abcli/
+tmp_*/
+
 # IDE
 .idea/
 .vscode/

--- a/src/designdoc/cli.py
+++ b/src/designdoc/cli.py
@@ -104,7 +104,10 @@ async def _run_orchestrator(
     if budget_usd is not None:
         state.halted_on_budget = False
     budget = CostAccumulator.load_or_new(cap_usd=cap_usd, path=output / BUDGET_FILENAME)
-    runner = ClaudeSDKRunner(budget=budget)
+    # Issue #46: pin the SDK subprocess to the target repo so its Read/Grep
+    # tools resolve paths against the source we're documenting, not against
+    # wherever the user happened to invoke `designdoc` from.
+    runner = ClaudeSDKRunner(budget=budget, cwd=str(repo))
     orchestrator = Orchestrator(
         state=state, runner=runner, budget=budget, config=config, skip_stages=skip
     )

--- a/src/designdoc/runner.py
+++ b/src/designdoc/runner.py
@@ -51,12 +51,23 @@ class RunnerProtocol(Protocol):
 
 
 class ClaudeSDKRunner:
-    def __init__(self, budget: CostAccumulator, sdk: SDKProtocol | None = None):
+    def __init__(
+        self,
+        budget: CostAccumulator,
+        sdk: SDKProtocol | None = None,
+        cwd: str | None = None,
+    ):
+        """cwd: working directory to expose to the SDK subprocess. When set,
+        every options dict carries it through to ClaudeAgentOptions.cwd, so
+        the SDK's Read/Grep tools resolve relative paths against the **target
+        repo** rather than wherever the user invoked the CLI from. Issue #46.
+        """
         self.budget = budget
         self.sdk = sdk if sdk is not None else _DefaultSDK()
+        self.cwd = cwd
 
     async def run(self, agent: AgentDef, prompt: str) -> RunResult:
-        options = _build_options(agent)
+        options = _build_options(agent, cwd=self.cwd)
         resp = await self.sdk.query(prompt=prompt, options=options)
         usage = resp.get("usage", {}) or {}
         rec = UsageRecord(
@@ -74,7 +85,7 @@ class ClaudeSDKRunner:
         )
 
 
-def _build_options(agent: AgentDef) -> dict:
+def _build_options(agent: AgentDef, cwd: str | None = None) -> dict:
     """Translate AgentDef into the options dict passed to the SDK.
 
     When agent.mcp_servers is non-empty:
@@ -83,6 +94,12 @@ def _build_options(agent: AgentDef) -> dict:
     - Adds setting_sources=["user", "project", "local"] so MCP server
       configs declared in ~/.claude.json, .mcp.json, or project local
       flow through without us having to hand-wire each server's transport.
+
+    When cwd is provided (issue #46), it is included in the options dict
+    so the SDK subprocess uses it as its working directory. Without this,
+    the SDK's Read/Grep tools resolve paths relative to wherever the user
+    invoked the CLI from — and class_documenter cannot read source files
+    in the target repo when target_repo != cli_invocation_cwd.
     """
     tools = list(agent.allowed_tools)
     extras: dict = {}
@@ -90,6 +107,8 @@ def _build_options(agent: AgentDef) -> dict:
         for server in agent.mcp_servers:
             tools.append(f"mcp__{server}__*")
         extras["setting_sources"] = ["user", "project", "local"]
+    if cwd is not None:
+        extras["cwd"] = cwd
 
     return {
         "system_prompt": agent.system_prompt,
@@ -116,6 +135,10 @@ class _DefaultSDK:
         extra: dict = {}
         if options.get("setting_sources"):
             extra["setting_sources"] = options["setting_sources"]
+        if options.get("cwd"):
+            # Issue #46: pin the SDK subprocess to the target repo so its
+            # Read/Grep tools see the source files we're documenting.
+            extra["cwd"] = options["cwd"]
         # MCP server dict is built from inherited settings — we don't pass
         # explicit configs here; agent names flow via allowed_tools patterns.
         opts = ClaudeAgentOptions(

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -86,6 +86,72 @@ async def test_runner_passes_agent_config_to_sdk():
 
 
 @pytest.mark.anyio
+async def test_runner_passes_cwd_to_sdk_options():
+    """Issue #46: when the runner is configured with a cwd, every options
+    dict passed to the SDK must contain it. This is what lets the SDK
+    subprocess Read source files in the target repo when the user invokes
+    designdoc from a different working directory.
+    """
+    budget = CostAccumulator(cap_usd=1.00)
+    fake = FakeSDK(
+        [{"text": "", "usage": {"input_tokens": 0, "output_tokens": 0, "cost_usd": 0.0}}]
+    )
+    r = ClaudeSDKRunner(budget=budget, sdk=fake, cwd="/tmp/some-target-repo")
+    agent = AgentDef(name="t", system_prompt="", model="m")
+
+    await r.run(agent, prompt="hi")
+
+    assert len(fake.calls) == 1
+    _, options = fake.calls[0]
+    assert options["cwd"] == "/tmp/some-target-repo"
+
+
+@pytest.mark.anyio
+async def test_runner_omits_cwd_when_none():
+    """Backward-compat: if no cwd is supplied, the options dict must not
+    include a cwd key (the SDK falls back to its default behavior)."""
+    budget = CostAccumulator(cap_usd=1.00)
+    fake = FakeSDK(
+        [{"text": "", "usage": {"input_tokens": 0, "output_tokens": 0, "cost_usd": 0.0}}]
+    )
+    r = ClaudeSDKRunner(budget=budget, sdk=fake)  # no cwd
+    agent = AgentDef(name="t", system_prompt="", model="m")
+
+    await r.run(agent, prompt="hi")
+
+    _, options = fake.calls[0]
+    assert "cwd" not in options
+
+
+@pytest.mark.anyio
+async def test_runner_uses_out_of_tree_cwd(tmp_path):
+    """Issue #46 regression: pytest's tmp_path is outside the docgen tree
+    by design. This is the closest CI-level approximation of the
+    realistic case 'user runs designdoc from /Users/me/work, target repo
+    is /Users/me/projects/foo' that surfaced the bug in the agent-brain
+    eval. The captured cwd must match the target path string-for-string.
+    """
+    target = tmp_path / "target_repo"
+    target.mkdir()
+    (target / "main.py").write_text("class X:\n    pass\n")
+
+    budget = CostAccumulator(cap_usd=1.00)
+    fake = FakeSDK(
+        [{"text": "", "usage": {"input_tokens": 0, "output_tokens": 0, "cost_usd": 0.0}}]
+    )
+    r = ClaudeSDKRunner(budget=budget, sdk=fake, cwd=str(target))
+    agent = AgentDef(name="class-documenter", system_prompt="", model="m", allowed_tools=["Read"])
+
+    await r.run(agent, prompt="document the class in main.py")
+
+    _, options = fake.calls[0]
+    assert options["cwd"] == str(target)
+    assert "Read" in options["allowed_tools"], (
+        "Read must be enabled — issue #46 is about Read access in the target repo"
+    )
+
+
+@pytest.mark.anyio
 async def test_runner_budget_exceeded_propagates():
     budget = CostAccumulator(cap_usd=0.10)
     fake = FakeSDK(


### PR DESCRIPTION
## Summary

Pass the target repo path as \`cwd\` into every \`ClaudeAgentOptions\` constructed by the runner. Without this, the SDK subprocess's \`Read\`/\`Grep\` tools resolve paths against the user's CLI invocation cwd, not against the target repo — and Stage 3 \`class_documenter\` cannot read source files for the very classes it's documenting.

## Why (PyPI blocker)

Real-eval evidence on agent-brain (\`$90\` budget, full Stage 3 attempted):

| Stage 3 metric | Value | Interpretation |
|---|---|---|
| HIL disputes | **39 / 70** (56%) | doc shipped with \`<!-- HIL: HIL-NNN -->\` after 3 retries |
| \`doer_content_retries\` | 60 | doer kept failing, kept retrying |
| \`checker_parse_retries\` | 43 | (separate issue, follow-up) |
| Cost wasted on retries | ~$30 | unrecoverable spend |

Sample HIL-001 \`checker_said\`: *"Source file \`agent-brain-cli/agent_brain_cli/client/api_client.py\` is **inaccessible from this session's sandbox**. Zero claims in the generated doc are traceable to code…"*

The doer correctly diagnosed its own broken sandbox; the checker correctly rejected unverifiable claims. The pipeline did its job — but couldn't recover because the *only* way out was to give Read access to the target repo, and the runner never plumbed cwd through.

This is **THE** PyPI blocker. designdoc's value proposition ("walks any repo, emits validated docs") doesn't hold for the realistic case "I run \`designdoc\` from my dev shell against \`/Users/me/projects/foo\`."

## Why CI didn't catch this

\`tests/fixtures/tiny_repo\` lives **inside the docgen tree**. When the SDK subprocess inherits docgen's cwd, the target paths just happen to resolve. The bug was structurally invisible until someone ran designdoc against a target outside the docgen tree.

This PR's regression test uses pytest's \`tmp_path\` (which is always outside the project root by design) to simulate the realistic case.

## Changes

- \`src/designdoc/runner.py\`:
  - \`ClaudeSDKRunner.__init__\` now accepts \`cwd: str | None = None\`.
  - \`_build_options\` threads cwd into the options dict via the \`extras\` mechanism (only when set, so backward-compat is preserved).
  - \`_DefaultSDK.query\` passes \`cwd\` through to \`ClaudeAgentOptions(cwd=...)\` when present.
- \`src/designdoc/cli.py\`: \`_run_orchestrator\` constructs the runner with \`cwd=str(repo)\`.
- \`.gitignore\`: drive-by — adds \`tmp_abcli/\` and \`tmp_*/\` patterns. A stray 1.5GB local-tool scratch venv was showing up in \`git status\` mid-PR and almost got swept into the commit. Defensive ignore.

## Tests (TWRC)

\`tests/unit/test_runner.py\` adds three tests, all written **red first**:

- \`test_runner_passes_cwd_to_sdk_options\` — runner constructed with \`cwd=\"/tmp/some-target-repo\"\` → captured options dict has matching \`cwd\` key.
- \`test_runner_omits_cwd_when_none\` — backward-compat: no cwd → no \`cwd\` key in options. Existing tests stay green.
- \`test_runner_uses_out_of_tree_cwd\` — uses \`tmp_path\` to simulate the agent-brain scenario in CI. Asserts \`Read\` is in allowed_tools (the bug's necessary condition) and that \`cwd\` matches the out-of-tree target path.

The third test is the regression guard. Without the fix, \`tmp_path\` would simulate the bug; with the fix, plumbing works.

## Invariants

Pure runner-plumbing change. No \`loop.py\`, no \`verdict.py\`, no \`mermaid/loop.py\`, no schema/checker logic touched.

- [x] MAX_ATTEMPTS=3 preserved (loop.py)
- [x] Checker isolation preserved (no self-grading)
- [x] Schema-validated verdicts / fail-loud preserved
- [x] Mermaid two-checker (mmdc + LLM) preserved
- [x] HIL fallback preserved

## Verification

- [x] \`task ci\` green locally — lint + format + 14 unit + 106 integration pass.
- [x] Failing tests written first; pass after the source changes.
- [x] No regression in 3 existing \`test_runner.py\` tests.
- [ ] **Real-world verification**: re-run agent-brain eval after merge. Expect Stage 3 HIL rate to drop from 56% to single digits, and \`doer_content_retries\` to drop from 60 to under 10. (Will report comparison numbers in #46.)

## Followups not in this PR

- \`extract_json_object\` should also be applied to the **checker** parse path (\`verdict.py:parse_verdict\`) — that's the other 43 retries observed. Symmetric extension of #41's fix.
- The \`★ Insight ───\` blocks polluting class doc preambles likely come from session-style inheritance — separate diagnosis.
- The cost-meter \`total_input_tokens\` undercount (846 across 220 calls is implausible).

These are follow-up issues, not this PR's scope.

## Related

- Closes #46.
- Stage-2-side equivalent shipped in #44 (\`extract_json_object\` for the doer path).
- Tooling-dirs exclusion shipped in #43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)