### PR TITLE
fix(runner): hermetic mode for non-MCP agents — closes #49

### DIFF
--- a/src/designdoc/runner.py
+++ b/src/designdoc/runner.py
@@ -107,6 +107,14 @@ def _build_options(agent: AgentDef, cwd: str | None = None) -> dict:
         for server in agent.mcp_servers:
             tools.append(f"mcp__{server}__*")
         extras["setting_sources"] = ["user", "project", "local"]
+    else:
+        # Issue #49: hermetic non-MCP agents. Without this, the SDK's default
+        # (setting_sources=None → load user+project+local) pulls in
+        # ~/.claude/CLAUDE.md, the target repo's CLAUDE.md, and the user's
+        # active output style — polluting class docs with `★ Insight ───` blocks
+        # and absorbing target-repo conventions into the doer's reasoning.
+        # SDK contract: setting_sources=[] means "isolation mode."
+        extras["setting_sources"] = []
     if cwd is not None:
         extras["cwd"] = cwd
 
@@ -133,7 +141,9 @@ class _DefaultSDK:
         )
 
         extra: dict = {}
-        if options.get("setting_sources"):
+        if "setting_sources" in options:
+            # Note: explicit `[]` (isolation mode for issue #49) is falsy.
+            # `if options.get(...)` would silently drop it; `in` is correct.
             extra["setting_sources"] = options["setting_sources"]
         if options.get("cwd"):
             # Issue #46: pin the SDK subprocess to the target repo so its

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -152,6 +152,66 @@ async def test_runner_uses_out_of_tree_cwd(tmp_path):
 
 
 @pytest.mark.anyio
+async def test_runner_isolates_non_mcp_agents():
+    """Issue #49: doers/checkers without MCP servers should run hermetic —
+    the SDK must NOT load user/project CLAUDE.md, output styles, or other
+    ambient config that would pollute their output (e.g. ★ Insight ─── blocks
+    inherited from the user's session output-style preference).
+
+    The SDK contract: setting_sources=[] means "isolation mode, no filesystem
+    settings." That's what we want for class_documenter and friends.
+    """
+    budget = CostAccumulator(cap_usd=1.00)
+    fake = FakeSDK(
+        [{"text": "", "usage": {"input_tokens": 0, "output_tokens": 0, "cost_usd": 0.0}}]
+    )
+    r = ClaudeSDKRunner(budget=budget, sdk=fake)
+    agent = AgentDef(
+        name="class-documenter",
+        system_prompt="hermetic prompt",
+        model="m",
+        allowed_tools=["Read", "Grep"],
+        # NOTE: no mcp_servers
+    )
+
+    await r.run(agent, prompt="document a class")
+
+    _, options = fake.calls[0]
+    assert "setting_sources" in options, (
+        "non-MCP agents must explicitly request isolation mode (setting_sources=[]) "
+        "rather than rely on SDK default behavior, which loads ALL settings"
+    )
+    assert options["setting_sources"] == [], (
+        "non-MCP agents must run hermetic — empty setting_sources list"
+    )
+
+
+@pytest.mark.anyio
+async def test_runner_loads_settings_for_mcp_agents():
+    """MCP-using agents (e.g. tech_debt researcher with Perplexity / Context7)
+    NEED user/project settings to discover MCP server configs declared in
+    ~/.claude.json or .mcp.json. So setting_sources stays as user+project+local
+    in that case — only the non-MCP path becomes hermetic."""
+    budget = CostAccumulator(cap_usd=1.00)
+    fake = FakeSDK(
+        [{"text": "", "usage": {"input_tokens": 0, "output_tokens": 0, "cost_usd": 0.0}}]
+    )
+    r = ClaudeSDKRunner(budget=budget, sdk=fake)
+    agent = AgentDef(
+        name="tech-debt-researcher",
+        system_prompt="research deps",
+        model="m",
+        allowed_tools=["Read"],
+        mcp_servers=["perplexity-ask", "context7"],
+    )
+
+    await r.run(agent, prompt="research")
+
+    _, options = fake.calls[0]
+    assert options["setting_sources"] == ["user", "project", "local"]
+
+
+@pytest.mark.anyio
 async def test_runner_budget_exceeded_propagates():
     budget = CostAccumulator(cap_usd=0.10)
     fake = FakeSDK(


### PR DESCRIPTION
## Summary

Make non-MCP doer/checker subprocesses run in SDK isolation mode (\`setting_sources=[]\`) so they stop inheriting the user's session output style, target repo's CLAUDE.md, and other ambient configuration.

## Why

Real-eval against agent-brain produced class docs with \`★ Insight ─────────\` formatted blocks before every \`## Purpose\` header — directly contradicting the system prompt rule "no preamble before ## Purpose."

Root cause: the SDK's \`ClaudeAgentOptions.setting_sources=None\` default (issue #49) means "load all sources matching CLI defaults" — \`~/.claude/CLAUDE.md\`, target repo CLAUDE.md, \`.claude/settings.json\`, and any active output style. The user was in 'learning' output style during the eval; that style's "\`★ Insight ───\` blocks" instruction propagated into every class_documenter call.

The architectural intent of designdoc's harness engineering is that doers/checkers run hermetic — only their own \`AgentDef.system_prompt\` is authoritative. The SDK default subverts that.

## Changes

\`src/designdoc/runner.py\`:

- \`_build_options\` now sets \`setting_sources=[]\` for non-MCP agents (the new isolation branch). MCP-using agents (\`tech_debt\` researcher/cross-ref via Perplexity / Context7) keep \`["user", "project", "local"]\` because their server configs live in those settings files.
- \`_DefaultSDK.query\` truthy-check bug fix: \`if options.get("setting_sources"):\` would silently drop \`[]\` (falsy in Python). Changed to \`if "setting_sources" in options:\` so explicit isolation requests propagate. Without this fix, the \`extras["setting_sources"] = []\` from \`_build_options\` would be dead code.

## Verification

**Unit (TWRC):**
- \`test_runner_isolates_non_mcp_agents\` — non-MCP agent → captured options has \`setting_sources=[]\`. Written red first; passes after the fix.
- \`test_runner_loads_settings_for_mcp_agents\` — MCP agent → \`setting_sources=["user","project","local"]\`. Locks in existing behavior so a future refactor can't quietly hermetic-ize the MCP path.

**Real-world A/B on tiny_repo (the dogfood fixture):**

| | Pre-fix baseline (existing dogfood output) | Post-fix |
|---|---|---|
| \`★ Insight\` blocks | **4** across 3 class docs | **0** |
| HIL markers | n/a | 0 / 3 |
| Stages run | 0-3 | 0-3 (\`--skip mermaid --skip tech_debt --skip system_rollup --skip finalize\`) |

Same target, same pipeline, only the runner code changed. Sample post-fix doc opens with \`## Purpose\` directly (modulo one short benign sentence preamble — natural LLM polite-mode, not session-style contamination).

## Invariants

Pure runner-options change. No \`loop.py\`, no \`verdict.py\`, no \`mermaid/loop.py\`, no schema/checker logic touched.

- [x] MAX_ATTEMPTS=3 preserved (loop.py)
- [x] Checker isolation preserved (no self-grading)
- [x] Schema-validated verdicts / fail-loud preserved
- [x] Mermaid two-checker (mmdc + LLM) preserved
- [x] HIL fallback preserved

\`task ci\` green locally — lint + format + 14 unit + 106 integration tests pass.

## Followup not in this PR

The benign one-line preamble "Here is the design-documentation for the X class:" is still there — natural LLM polite-mode response. Could be addressed by tightening \`CLASS_DOCUMENTER_SYSTEM\` prompt (e.g. "First line of output must be \`## Purpose\`") or post-processing. Cosmetic, not blocking 1.2.1.

## Related

- Closes #49.
- Sibling PRs in the 1.2.1 prep train: #43 (excludes), #44 (Stage 2 tolerant JSON), #47 (cwd plumbing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)