### PR TITLE
chore(gitignore): docs/gen/ namespace for generated trees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,10 +28,10 @@ docs/design/.designdoc-budget.json
 # runs; never committed because they change every run with real LLM output.
 tests/fixtures/*/docs/design/
 
-# Local eval runs against external repos — generated docs, never committed.
-docs/agent-brain/
-docs/agent-memory/
-docs/eval/
+# Generated doc trees (designdoc output) — every target under docs/gen/<name>/
+# is ignored. Hand-written docs (e.g. docs/superpowers/) live at docs/<name>/
+# and remain tracked.
+docs/gen/
 
 # Stray local-tool scratch dirs that occasionally land in the repo root.
 tmp_abcli/


### PR DESCRIPTION
## Summary

Replaces the per-target list (`docs/agent-brain/`, `docs/agent-memory/`, `docs/eval/`) with a single `docs/gen/` line. Going forward, every designdoc-generated tree lives under `docs/gen/<target>/` and the gitignore catches them all without per-target maintenance.

Hand-written docs (e.g. `docs/superpowers/` plans + specs) stay at `docs/<name>/` and remain tracked.

## Why

Established during the May 2026 trust eval as a scaling pattern — \"we're going to generate a lot of these.\" Three lines of per-target maintenance became one line of namespace convention.

## Invariants preserved

- No source code change.
- Existing committed `docs/superpowers/` tree untouched.
- `docs/design/.designdoc-state.json` / `.designdoc-budget.json` lines (24-25) and `tests/fixtures/*/docs/design/` (line 29) stay as-is — different namespace.

## Test plan

- [x] `git status` clean after the change (no inadvertent file moves)
- [x] `task ci` is unaffected (this is gitignore-only)
- [ ] Next run of `designdoc generate --output docs/gen/<target>` produces an ignored tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)