### PR TITLE
fix(runner): retry transient SDK transport errors — closes #54

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,17 @@ its own repo are fixed; the ULTRAREVIEW follow-up hardening pass also lands.
   excludes `.claude/`, `.opencode/`, `.devcontainer/`, `.idea/`, and
   `.vscode/` by default. Previously these dirs polluted the language
   manifest with agent prompts and IDE config files, wasting Stage 1 budget.
+- **Runner retries transient SDK transport errors (#54).** The bundled
+  `claude-agent-sdk` CLI subprocess occasionally exits 1 mid-stream with a
+  generic "Command failed with exit code" error. Previously a single flake
+  aborted the entire stage's `asyncio.TaskGroup`, cancelling every sibling
+  task; recovery required manual `designdoc resume` (and got the same
+  treatment a few classes later). `ClaudeSDKRunner` now wraps the SDK call
+  with up to 3 retries on transport-level errors using exponential backoff
+  (1s, 2s, 4s). Non-transport errors propagate immediately so real bugs
+  aren't masked. Validated on the agent-brain monorepo eval: pre-fix needed
+  30 bash-loop iterations to complete Stage 5; post-fix expected to land
+  in 1-2.
 
 ### Hardened (ULTRAREVIEW follow-up — issues #6-#18)
 

--- a/src/designdoc/runner.py
+++ b/src/designdoc/runner.py
@@ -11,10 +11,35 @@ Tests inject a fake `sdk` so unit tests run offline.
 
 from __future__ import annotations
 
+import asyncio
+import logging
 from dataclasses import dataclass, field
 from typing import Protocol
 
 from designdoc.budget import CostAccumulator, UsageRecord
+
+log = logging.getLogger(__name__)
+
+# Issue #54: the bundled claude-agent-sdk CLI subprocess occasionally exits 1
+# with a generic "Command failed with exit code" error. Treat that class of
+# failure as retryable transport noise, not as a real run failure. The cap is
+# bounded (not user-configurable) for the same reason as MAX_ATTEMPTS in
+# loop.py: it's a correctness knob, not a tuning knob.
+MAX_TRANSPORT_RETRIES = 3
+
+
+def _is_transport_error(exc: BaseException) -> bool:
+    """Return True for retryable transport-level errors from claude_agent_sdk.
+
+    Covers both `claude_agent_sdk.ProcessError` (raised by the subprocess
+    transport at exit) and the plain `Exception` raised by the SDK's message
+    receiver when an "error"-type protocol message is encountered. We match
+    on class name + message substring so this module stays importable in unit
+    tests without a real `claude_agent_sdk` install.
+    """
+    if exc.__class__.__name__ == "ProcessError":
+        return True
+    return "Command failed with exit code" in str(exc)
 
 
 @dataclass
@@ -56,19 +81,25 @@ class ClaudeSDKRunner:
         budget: CostAccumulator,
         sdk: SDKProtocol | None = None,
         cwd: str | None = None,
+        transport_retry_backoff: float = 1.0,
     ):
         """cwd: working directory to expose to the SDK subprocess. When set,
         every options dict carries it through to ClaudeAgentOptions.cwd, so
         the SDK's Read/Grep tools resolve relative paths against the **target
         repo** rather than wherever the user invoked the CLI from. Issue #46.
+
+        transport_retry_backoff: base seconds for exponential backoff between
+        transport-error retries (1.0 → 1s, 2s, 4s). Issue #54. Tests pass 0.0
+        to keep the suite fast; real callers leave the default.
         """
         self.budget = budget
         self.sdk = sdk if sdk is not None else _DefaultSDK()
         self.cwd = cwd
+        self.transport_retry_backoff = transport_retry_backoff
 
     async def run(self, agent: AgentDef, prompt: str) -> RunResult:
         options = _build_options(agent, cwd=self.cwd)
-        resp = await self.sdk.query(prompt=prompt, options=options)
+        resp = await self._query_with_retry(agent.name, prompt, options)
         usage = resp.get("usage", {}) or {}
         rec = UsageRecord(
             input_tokens=usage.get("input_tokens", 0),
@@ -83,6 +114,45 @@ class ClaudeSDKRunner:
             output_tokens=rec.output_tokens,
             cost_usd=rec.cost_usd,
         )
+
+    async def _query_with_retry(self, agent_name: str, prompt: str, options: dict) -> dict:
+        """Call self.sdk.query with bounded retry on transport-level errors.
+
+        Issue #54: the bundled claude CLI subprocess occasionally exits 1 mid
+        stream; the SDK surfaces this as an Exception whose message starts with
+        "Command failed with exit code". A single flake should not abort the
+        whole stage's TaskGroup — retry up to MAX_TRANSPORT_RETRIES times with
+        exponential backoff. Non-transport exceptions propagate immediately
+        so real bugs aren't masked by retry-and-delay.
+        """
+        last_exc: BaseException | None = None
+        for attempt in range(MAX_TRANSPORT_RETRIES + 1):
+            try:
+                return await self.sdk.query(prompt=prompt, options=options)
+            except Exception as exc:
+                if not _is_transport_error(exc):
+                    raise
+                last_exc = exc
+                if attempt == MAX_TRANSPORT_RETRIES:
+                    log.warning(
+                        "agent %s: transport error after %d attempts, giving up: %s",
+                        agent_name,
+                        attempt + 1,
+                        exc,
+                    )
+                    raise
+                sleep_s = self.transport_retry_backoff * (2**attempt)
+                log.warning(
+                    "agent %s: transport error on attempt %d (%s); retrying in %.1fs",
+                    agent_name,
+                    attempt + 1,
+                    exc,
+                    sleep_s,
+                )
+                if sleep_s > 0:
+                    await asyncio.sleep(sleep_s)
+        # Unreachable: the loop above either returns or raises.
+        raise last_exc  # type: ignore[misc]
 
 
 def _build_options(agent: AgentDef, cwd: str | None = None) -> dict:

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -228,3 +228,96 @@ async def test_runner_budget_exceeded_propagates():
     # budget must be intact — the failed invocation did NOT mutate state
     assert budget.total_cost_usd == 0.0
     assert budget.invocations == 0
+
+
+class FlakingSDK:
+    """Fake SDK that raises a transport-style exception on the first
+    `fail_count` calls, then returns `response` on subsequent calls.
+
+    Models the real-world #54 symptom: bundled claude CLI subprocess
+    occasionally exits 1 and the SDK surfaces it as a generic Exception
+    whose message starts with 'Command failed with exit code'.
+    """
+
+    def __init__(self, fail_count: int, response: dict):
+        self.fail_count = fail_count
+        self.response = response
+        self.attempts = 0
+
+    async def query(self, *, prompt: str, options: dict) -> dict:
+        self.attempts += 1
+        if self.attempts <= self.fail_count:
+            raise Exception("Command failed with exit code 1 (exit code: 1)")
+        return self.response
+
+
+@pytest.mark.anyio
+async def test_runner_retries_transient_transport_errors():
+    """Issue #54: a single bundled-CLI flake must not abort the run.
+    Runner wraps the SDK call in bounded retry; the caller should see the
+    eventual successful result with no awareness that retries happened."""
+    budget = CostAccumulator(cap_usd=1.00)
+    sdk = FlakingSDK(
+        fail_count=2,
+        response={
+            "text": "doc body",
+            "usage": {"input_tokens": 100, "output_tokens": 50, "cost_usd": 0.01},
+        },
+    )
+    r = ClaudeSDKRunner(budget=budget, sdk=sdk, transport_retry_backoff=0.0)
+    agent = AgentDef(name="t", system_prompt="p", model="m")
+
+    out = await r.run(agent, prompt="hi")
+
+    assert out.text == "doc body"
+    assert sdk.attempts == 3, "runner should have attempted twice and succeeded on the third"
+    # budget accrues exactly once — the failed transport attempts cost nothing
+    assert budget.invocations == 1
+    assert budget.total_cost_usd == 0.01
+
+
+@pytest.mark.anyio
+async def test_runner_gives_up_after_max_transport_retries():
+    """Runner retries are bounded. After N failures, the last exception
+    propagates so the caller can surface a real error rather than silently
+    looping forever."""
+    budget = CostAccumulator(cap_usd=1.00)
+    sdk = FlakingSDK(
+        fail_count=99,  # always fail
+        response={"text": "never reached", "usage": {}},
+    )
+    r = ClaudeSDKRunner(budget=budget, sdk=sdk, transport_retry_backoff=0.0)
+    agent = AgentDef(name="t", system_prompt="p", model="m")
+
+    with pytest.raises(Exception, match="Command failed with exit code"):
+        await r.run(agent, prompt="hi")
+
+    # bounded: must not loop forever. 1 initial + N retries.
+    assert sdk.attempts <= 4, f"runner attempted {sdk.attempts} times — retry budget is unbounded"
+    # nothing accrued
+    assert budget.invocations == 0
+
+
+@pytest.mark.anyio
+async def test_runner_does_not_retry_non_transport_errors():
+    """Retries are scoped to transport-level flakes. A programming error
+    (ValueError, TypeError, etc.) must propagate immediately so it isn't
+    masked by 3 retry attempts and a sleep that delays the real signal."""
+    budget = CostAccumulator(cap_usd=1.00)
+
+    class ValueErrorSDK:
+        def __init__(self):
+            self.attempts = 0
+
+        async def query(self, *, prompt: str, options: dict) -> dict:
+            self.attempts += 1
+            raise ValueError("not a transport error")
+
+    sdk = ValueErrorSDK()
+    r = ClaudeSDKRunner(budget=budget, sdk=sdk, transport_retry_backoff=0.0)
+    agent = AgentDef(name="t", system_prompt="p", model="m")
+
+    with pytest.raises(ValueError, match="not a transport error"):
+        await r.run(agent, prompt="hi")
+
+    assert sdk.attempts == 1, "non-transport errors must not trigger retries"


### PR DESCRIPTION
## Summary

Closes #54. The dominant pipeline-reliability gap surfaced by the May 2026 agent-brain trust eval: a 1-in-N transport flake from the bundled claude-agent-sdk CLI subprocess was aborting the entire stage TaskGroup. Pre-fix, the eval needed **30 bash-loop iterations** to complete Stage 5 — 29 wasted on retry-after-flake. Post-fix expected: 1-2 iterations.

## Change

`ClaudeSDKRunner._query_with_retry` wraps `self.sdk.query()` with:
- Up to `MAX_TRANSPORT_RETRIES = 3` retries (4 total attempts max)
- Exponential backoff (1s, 2s, 4s base)
- Scoped to transport-level failure modes only via `_is_transport_error`:
  - `claude_agent_sdk.ProcessError` (raised by the subprocess transport)
  - Plain `Exception` whose message contains "Command failed with exit code" (raised by the SDK's message receiver on error-type protocol messages)
- Non-transport exceptions propagate immediately

`MAX_TRANSPORT_RETRIES` lives at module top as a constant, **not exposed in `Config`** — same constitutional discipline as `MAX_ATTEMPTS` in `loop.py`. It's a correctness knob, not a tuning knob.

## Test plan

Three new unit tests in `tests/unit/test_runner.py`:

- `test_runner_retries_transient_transport_errors` — `FlakingSDK` raises 2 transport-style exceptions then succeeds; runner returns the successful result, `sdk.attempts == 3`, budget accrues exactly once.
- `test_runner_gives_up_after_max_transport_retries` — `FlakingSDK` raises 99 times; runner gives up after 4 attempts (1 initial + 3 retries), re-raises the last exception, budget unchanged.
- `test_runner_does_not_retry_non_transport_errors` — SDK raises `ValueError`; runner propagates after 1 attempt, no retries.

All tests pass `transport_retry_backoff=0.0` to keep the suite fast. Existing 8 runner tests still pass (verified `task ci` green locally: 106 passed in 50.56s).

## Invariants preserved

- **`MAX_ATTEMPTS = 3`** in `loop.py` unchanged. Guard test `test_config_does_not_expose_max_attempts` still passes.
- **Doer/checker isolation** unchanged — retries are inside the runner, not the loop.
- **Schema-validated verdicts** unchanged.
- **No new config field.** `MAX_TRANSPORT_RETRIES` is a module constant.

## CHANGELOG

Added a 5th \"Fixed\" bullet under v1.2.1. This unblocks tagging.

## Out of scope

- Why the bundled CLI exits 1. The SDK doesn't surface stderr; needs separate investigation if it persists. The retry treats the symptom; root cause remains open.
- Cause-specific retry behavior (e.g., different backoff for capacity-style vs network-style errors). All transport failures get the same 3-retry treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)