### PR TITLE
feat(stage5): per-package overview diagrams in package READMEs

### DIFF
--- a/src/designdoc/stages/s5_mermaid.py
+++ b/src/designdoc/stages/s5_mermaid.py
@@ -24,13 +24,23 @@ import re
 from designdoc.hil import inline_comment
 from designdoc.io_utils import atomic_write
 from designdoc.mermaid.loop import generate_validated_mermaid, strip_fence
-from designdoc.mermaid.mmdc import preflight
+from designdoc.mermaid.mmdc import preflight, validate
 from designdoc.state import PipelineState, StageStatus, state_lock
 
 STAGE_NAME = "mermaid"
 
 # Matches "## Diagram" through the end of the file (i.e. the whole section).
 _DIAGRAM_SECTION_RE = re.compile(r"\n*##\s+Diagram\b.*", re.DOTALL)
+
+# Captures a fenced mermaid block's body (the text between the ``` markers).
+_MERMAID_FENCE_RE = re.compile(r"```mermaid\n([\s\S]+?)\n```")
+
+# Mermaid classDiagram relationship operators. Lines containing any of these
+# (and not also a class-block opener) are treated as relationships.
+_ARROW_OPS = ("-->", "<--", "..>", "<..", "--|>", "<|--", "*--", "--*", "o--", "--o")
+
+# Captures the class-name token from `class Foo` or `class Foo { ... }`.
+_CLASS_NAME_RE = re.compile(r"\bclass\s+(\w+)")
 
 
 async def run(
@@ -105,10 +115,116 @@ async def run(
             state.rollup_hashes[rollup_key] = input_hash
             state.save()
 
+    # Per-package overview diagrams. Synthesized by merging the per-class
+    # diagrams above; appended to each package README so the design-doc
+    # reader gets a bird's-eye view without burning extra LLM budget.
+    await _emit_package_diagrams(state, packages_dir)
+
     state.stages[STAGE_NAME] = StageStatus.DONE
     state.current_stage = max(state.current_stage, 6)
     state.save()
     return diagrams
+
+
+async def _emit_package_diagrams(state: PipelineState, packages_dir) -> None:
+    """For each package, merge its per-class diagrams into a slim overview
+    and append to the package README. Skips packages whose inputs haven't
+    changed since the last run (within-stage checkpoint) and packages whose
+    merged diagram fails mmdc validation (logged, not fatal).
+    """
+    for pkg_dir in sorted(p for p in packages_dir.iterdir() if p.is_dir()):
+        pkg_readme = pkg_dir / "README.md"
+        if not pkg_readme.exists():
+            continue
+        class_docs = sorted(pkg_dir.glob("classes/*.md"))
+        if not class_docs:
+            continue
+
+        blocks = []
+        for cd in class_docs:
+            m = _MERMAID_FENCE_RE.search(cd.read_text())
+            if m:
+                blocks.append(m.group(1))
+        if not blocks:
+            continue
+
+        # Hash the inputs so re-runs skip when nothing changed. Sorted so
+        # class-doc ordering doesn't invalidate the cache.
+        input_hash = _hash_body("\n---\n".join(sorted(blocks)))
+        rel = str(pkg_readme.relative_to(state.output_dir))
+        rollup_key = f"mermaid:{rel}"
+
+        pkg_text = pkg_readme.read_text()
+        prior = state.artifact_index.get(rollup_key, {})
+        if prior.get("input_hash") == input_hash and "## Diagram" in pkg_text:
+            continue
+        if state.rollup_hashes.get(rollup_key) == input_hash and "## Diagram" in pkg_text:
+            continue
+
+        merged = _merge_class_diagrams(blocks)
+        if not merged:
+            continue
+
+        validation = validate(merged)
+        if not validation.ok:
+            # Fail soft: leave the README diagram-less rather than crash the
+            # stage. Stage 5 is best-effort by design (per-class diagrams
+            # already use the same HIL-or-ship pattern).
+            continue
+
+        body = _strip_diagram_section(pkg_text)
+        section = f"\n\n## Diagram\n\n```mermaid\n{merged}\n```\n"
+        atomic_write(pkg_readme, body.rstrip() + section)
+
+        async with state_lock:
+            state.artifact_index[rollup_key] = {"path": rel, "input_hash": input_hash}
+            state.rollup_hashes[rollup_key] = input_hash
+            state.save()
+
+
+def _merge_class_diagrams(blocks: list[str]) -> str:
+    """Merge per-class mermaid classDiagram bodies into a slim package
+    overview: deduplicated class-name boxes + deduplicated relationship
+    arrows. Inner-class detail (fields / methods) is intentionally dropped —
+    that detail belongs in the per-class docs, not in the package overview.
+
+    Blocks that aren't classDiagram-style (e.g. flowchart, sequenceDiagram)
+    are ignored so a stray non-class diagram doesn't corrupt the merge.
+    Returns an empty string if no class names were found.
+    """
+    class_names: set[str] = set()
+    arrows: set[str] = set()
+
+    for block in blocks:
+        # Identify classDiagram blocks by the directive at the head. We do
+        # this rather than parse the directive line because the directive
+        # may be on the first or second line depending on producer style.
+        head = block.strip().splitlines()[0] if block.strip() else ""
+        if not head.lower().startswith("classdiagram"):
+            continue
+
+        for m in _CLASS_NAME_RE.finditer(block):
+            class_names.add(m.group(1))
+
+        for line in block.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            if stripped.lower().startswith("classdiagram"):
+                continue
+            # A line is a relationship if it contains an arrow operator AND
+            # does NOT start with `class ` (otherwise we'd grab class-block
+            # openers with `class Foo --> Bar` style inline declarations).
+            if any(op in stripped for op in _ARROW_OPS) and not stripped.startswith("class "):
+                arrows.add(stripped)
+
+    if not class_names:
+        return ""
+
+    lines = ["classDiagram"]
+    lines.extend(f"    class {name}" for name in sorted(class_names))
+    lines.extend(f"    {arrow}" for arrow in sorted(arrows))
+    return "\n".join(lines)
 
 
 def _strip_diagram_section(text: str) -> str:

--- a/tests/integration/test_stage_mermaid.py
+++ b/tests/integration/test_stage_mermaid.py
@@ -64,3 +64,78 @@ async def test_stage5_requires_packages_dir(tmp_path: Path):
     runner = ClaudeSDKRunner(budget=CostAccumulator(cap_usd=1.0), sdk=FakeSDK())
     with pytest.raises(FileNotFoundError):
         await stage_mermaid(state=state, runner=runner)
+
+
+class FakeSDKClassDiagram:
+    """Returns classDiagram-style mermaid (vs FakeSDK's flowchart). Needed
+    for the per-package merger test — the merger ignores non-classDiagram
+    blocks by design, so the integration test must produce real classDiagram
+    output."""
+
+    def __init__(self):
+        self._idx = 0
+
+    async def query(self, *, prompt: str, options: dict) -> dict:
+        system = options.get("system_prompt") or ""
+        if "mermaid diagram generator" in system:
+            # Alternate two different class diagrams so the merge has
+            # something to deduplicate.
+            self._idx += 1
+            if self._idx % 2 == 1:
+                text = "classDiagram\n    class Gateway\n    class Card\n    Gateway --> Card\n"
+            else:
+                text = "classDiagram\n    class Charge\n    class Card\n    Charge --> Card\n"
+            return {
+                "text": text,
+                "usage": {"input_tokens": 10, "output_tokens": 20, "cost_usd": 0.001},
+            }
+        if "mermaid-semantics reviewer" in system:
+            import json
+
+            return {
+                "text": json.dumps({"status": "pass", "summary": "ok"}),
+                "usage": {"input_tokens": 10, "output_tokens": 5, "cost_usd": 0.0005},
+            }
+        raise AssertionError(f"unexpected agent: {system[:80]}")
+
+
+@pytest.mark.requires_mmdc
+@pytest.mark.anyio
+async def test_stage5_appends_package_overview_diagram_to_readme(tmp_path: Path):
+    """Stage 5 emits a per-package overview diagram (merged from the
+    per-class diagrams) and appends it to each package README. Without this,
+    package READMEs ship diagram-less and readers must drill into individual
+    class docs to see any structural view of the package.
+    """
+    output = tmp_path / "design"
+    pkg_dir = output / "packages" / "payments"
+    classes_dir = pkg_dir / "classes"
+    classes_dir.mkdir(parents=True)
+    (classes_dir / "Gateway.md").write_text("## Purpose\nGateway class.")
+    (classes_dir / "Charge.md").write_text("## Purpose\nCharge class.")
+    # The package README must already exist (Stage 4 produces it). Pre-seed
+    # one without a Diagram section to mirror the real Stage 4 output.
+    (pkg_dir / "README.md").write_text(
+        "# payments\n\n## Overview\nHandles money. No diagram here yet.\n"
+    )
+
+    state = PipelineState.load_or_new(output_dir=output, target_repo=tmp_path)
+    runner = ClaudeSDKRunner(budget=CostAccumulator(cap_usd=1.0), sdk=FakeSDKClassDiagram())
+
+    await stage_mermaid(state=state, runner=runner)
+
+    readme_text = (pkg_dir / "README.md").read_text()
+    assert "## Diagram" in readme_text, (
+        "package README must gain a Diagram section after Stage 5 runs"
+    )
+    assert "```mermaid" in readme_text
+    assert "classDiagram" in readme_text
+    # The merger should have collected class names from both per-class docs
+    # AND deduplicated the shared `Card` class to a single declaration.
+    assert "class Card" in readme_text
+    assert "class Gateway" in readme_text
+    assert "class Charge" in readme_text
+    assert readme_text.count("class Card") == 1, (
+        "Card was declared in both Gateway.md and Charge.md diagrams; "
+        "the package overview must dedupe to a single declaration"
+    )

--- a/tests/unit/test_stage5_package_diagrams.py
+++ b/tests/unit/test_stage5_package_diagrams.py
@@ -1,0 +1,108 @@
+"""Unit tests for Stage 5's per-package classDiagram merger.
+
+Stage 5 generates one mermaid diagram per class. The package READMEs and
+the top-level system rollup had no diagrams at all — readers got prose-only
+design docs. The merger takes the per-class diagrams from a package and
+synthesizes a slim package-overview classDiagram (class names + relationship
+arrows, no inner-class detail), which Stage 5 appends to each package README.
+
+Detailed class internals already live in the per-class docs; the package
+overview is for the bird's-eye view.
+"""
+
+from __future__ import annotations
+
+from designdoc.stages.s5_mermaid import _merge_class_diagrams
+
+
+def test_merge_extracts_class_names_from_inputs():
+    """Each class declared in any input shows up exactly once."""
+    a = "classDiagram\n    class Gateway {\n        +charge()\n    }\n"
+    b = "classDiagram\n    class Charge {\n        +amount: float\n    }\n"
+
+    merged = _merge_class_diagrams([a, b])
+
+    assert "classDiagram" in merged
+    assert "class Charge" in merged
+    assert "class Gateway" in merged
+
+
+def test_merge_drops_inner_class_detail():
+    """The package overview is a bird's-eye view — fields and methods stay
+    in the per-class docs, not in the package README's overview diagram."""
+    a = (
+        "classDiagram\n"
+        "    class Gateway {\n"
+        "        +charge(card: Card) Charge\n"
+        "        -log(msg: str) void\n"
+        "        +api_key: str\n"
+        "    }\n"
+    )
+
+    merged = _merge_class_diagrams([a])
+
+    assert "class Gateway" in merged
+    # detail bodies are intentionally elided from the slim overview
+    assert "charge(card: Card)" not in merged
+    assert "api_key" not in merged
+
+
+def test_merge_dedupes_class_names_across_inputs():
+    """A class referenced from two sibling class docs (e.g., both Gateway.md
+    and Charge.md mention `class Card`) appears once in the merge."""
+    a = "classDiagram\n    class Gateway\n    class Card\n    Gateway --> Card\n"
+    b = "classDiagram\n    class Charge\n    class Card\n    Charge --> Card\n"
+
+    merged = _merge_class_diagrams([a, b])
+
+    # Card declared once across the merged output
+    assert merged.count("class Card") == 1
+    assert "class Gateway" in merged
+    assert "class Charge" in merged
+
+
+def test_merge_preserves_relationship_arrows():
+    """Inheritance, composition, dependency arrows survive the merge."""
+    a = (
+        "classDiagram\n"
+        "    class Animal\n"
+        "    class Dog\n"
+        "    Animal <|-- Dog\n"
+        "    Dog ..> Bone : fetches\n"
+    )
+
+    merged = _merge_class_diagrams([a])
+
+    assert "Animal <|-- Dog" in merged
+    assert "Dog ..> Bone" in merged
+
+
+def test_merge_dedupes_identical_arrows():
+    """Two class docs both declaring `Gateway --> Card` should produce one
+    arrow in the merge, not two."""
+    a = "classDiagram\n    class Gateway\n    class Card\n    Gateway --> Card\n"
+    b = "classDiagram\n    class Gateway\n    class Card\n    Gateway --> Card\n"
+
+    merged = _merge_class_diagrams([a, b])
+
+    assert merged.count("Gateway --> Card") == 1
+
+
+def test_merge_returns_empty_on_empty_input():
+    """No class blocks → nothing to draw; caller can skip the README append."""
+    assert _merge_class_diagrams([]) == ""
+    assert _merge_class_diagrams(["classDiagram\n"]) == ""
+
+
+def test_merge_ignores_non_classdiagram_blocks():
+    """Stage 5 sometimes produces flowchart-style diagrams (the FakeSDK in
+    integration tests does this). The merger should ignore blocks that
+    aren't classDiagram-style rather than corrupt the package overview."""
+    a = "classDiagram\n    class Gateway\n"
+    b = "flowchart TD\n    A --> B\n"
+
+    merged = _merge_class_diagrams([a, b])
+
+    assert "class Gateway" in merged
+    assert "flowchart" not in merged
+    assert "A --> B" not in merged


### PR DESCRIPTION
## Summary

Stage 5 now emits a slim package-overview classDiagram in each package README, synthesized from the package's per-class diagrams via text merge. **Zero LLM calls** — pure code path; no impact on the cost model.

## Why

The agent-brain trust eval (May 2026) surfaced the gap: 458/458 class docs had diagrams, but 0/24 package READMEs did. The user comment was:

> still not seeing anything anywhere

Per-class diagrams were buried at the bottom of individual class files; readers opening the package README to understand the package's structure saw prose only. This closes that gap at the package level. (System-level diagrams in SYSTEM_DESIGN.md / ARCHITECTURE.md is a separate, larger feature — Option B from the trust-eval triage; not included here.)

## How

After the per-class diagram loop, Stage 5 walks each package directory:

1. Read every class doc's mermaid body
2. Merge: deduplicate class-name boxes + relationship arrows; drop inner-class detail (fields, methods — that belongs in per-class docs)
3. Validate the merge with mmdc (same path Stage 5 already uses for per-class diagrams)
4. Append a `## Diagram` section to the package README
5. Checkpoint the result so re-runs skip when class diagrams haven't changed

The merger is defensive:
- Ignores non-classDiagram blocks (some producers emit flowchart/sequenceDiagram for individual classes)
- Mmdc-validation failure is fail-soft — the package overview is skipped; the per-class diagrams in that package still ship
- Empty input → empty output → no README append

## Test plan

- [x] **7 unit tests** for `_merge_class_diagrams` — name extraction, detail elision, dedupe across inputs, arrow preservation/dedupe, empty inputs, non-classDiagram filtering
- [x] **1 integration test** (`@pytest.mark.requires_mmdc`) — pre-seeds a `payments` package with `Gateway.md` and `Charge.md`, runs Stage 5 end-to-end with a `FakeSDKClassDiagram` that emits real classDiagram output (alternating between two distinct shapes so the merge has something to deduplicate), asserts the package README gains a `## Diagram` section, and confirms shared `Card` class declaration is deduplicated
- [x] `task ci` green locally (107 passed, +1 new test class)
- [ ] Real-API verification on agent-brain — covered by re-running designdoc resume against `docs/gen/agent-brain` after merge; expected zero additional LLM cost since per-class diagrams already exist and the merge is pure code

## Invariants preserved

- **`MAX_ATTEMPTS = 3`** unchanged
- **Doer/checker isolation** unchanged (no new agents — pure code merge)
- **Schema-validated verdicts** unchanged
- **Mermaid two-checker rule** — `mmdc.validate` runs on the merged diagram before it ships; LLM-side check skipped since the merge is deterministic text
- **Within-stage checkpointing** — package-overview entries use the same `state.artifact_index["mermaid:<rel>"]` shape as the per-class entries; re-runs cost nothing

## Cost model

Zero per-run cost. The merger is pure Python text processing + one mmdc validation per package. No LLM calls.

## Out of scope

- **System-level diagrams (Option B).** ARCHITECTURE.md and SYSTEM_DESIGN.md remain prose-only. That's a bigger feature (would need a new agent for high-level synthesis) and belongs in a separate PR.
- **PlantUML support.** Still v2 backlog per CLAUDE.md and `config.py:38`.
- **Schema-validated verdict for merged diagrams.** The merged output is pure text-merge of human-readable mermaid produced by the per-class doer/checker pair — running another LLM check would double the validation cost for marginal additional confidence. mmdc syntactic validation is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)